### PR TITLE
Bugfix: Removed imagehdr as its deprecated. Used Filetype. Bumped Ver…

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,8 @@ This project is licensed under the terms of the MIT license.
 ### Contact
 
 If you have any questions or feedback, please contact us at [email](mailto:shentharkrishnatejaswi@gmail.com).
+
+### Changelog
+
+- 1.1.3:
+  - Fixed issue with invalid image types. Deleted imghdr and used filetype to check image types.

--- a/better_bing_image_downloader/bing.py
+++ b/better_bing_image_downloader/bing.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 import urllib.request
 import urllib
-import imghdr
 import posixpath
 import re
 import logging
 from tqdm import tqdm
+import filetype
 
 '''
 
@@ -123,8 +123,8 @@ class Bing:
         try:
             request = urllib.request.Request(link, None, self.headers)
             image = urllib.request.urlopen(request, timeout=self.timeout).read()
-            if not imghdr.what(None, image):
-                
+            kind = filetype.guess(image)
+            if kind is None or not kind.mime.startswith('image/'):
                 logging.error('Invalid image, not saving %s', link)
                 raise ValueError('Invalid image, not saving %s' % link)
             with open(str(file_path), 'wb') as f:

--- a/better_bing_image_downloader/helperdownload.py
+++ b/better_bing_image_downloader/helperdownload.py
@@ -5,11 +5,11 @@
 from __future__ import print_function
 
 import shutil
-import imghdr
 import os
 import concurrent.futures
 import requests
 import socket
+import filetype
 
 headers = {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -39,16 +39,15 @@ def download_image(image_url, dst_dir, file_name, timeout=20, proxy_type=None, p
             with open(file_path, 'wb') as f:
                 f.write(response.content)
             response.close()
-            file_type = imghdr.what(file_path)
-            # if file_type is not None:
-            if file_type in ["jpg", "jpeg", "png", "bmp", "webp"]:
-                new_file_name = "{}.{}".format(file_name, file_type)
+            kind = filetype.guess(file_path)
+            if kind and kind.extension in ["jpg", "jpeg", "png", "bmp", "webp"]:
+                new_file_name = "{}.{}".format(file_name, kind.extension)
                 new_file_path = os.path.join(dst_dir, new_file_name)
                 shutil.move(file_path, new_file_path)
                 print("## OK:  {}  {}".format(new_file_name, image_url))
             else:
                 os.remove(file_path)
-                print("## Err: TYPE({})  {}".format(file_type, image_url))
+                print("## Err: Invalid image type  {}".format(image_url))
             break
         except Exception as e:
             if try_times < 3:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ charset-normalizer==3.3.2
 chromedriver-autoinstaller==0.6.4
 cryptography==42.0.2
 docutils==0.20.1
+filetype==1.2.0
 h11==0.14.0
 idna==3.6
 importlib-metadata==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="better_bing_image_downloader",
-    version="1.1.2",
+    version="1.1.3",
     author="Krishnatejaswi S",
     author_email="shentharkrishnatejaswi@gmail.com",
     description="This package is built on top of bing-image-downloader by gaurav singh",


### PR DESCRIPTION
This pull request includes several changes to the `better_bing_image_downloader` package, focusing on replacing the `imghdr` module with the `filetype` module for better image type validation and updating the package version.

### Image Type Validation Improvements:
* [`better_bing_image_downloader/bing.py`](diffhunk://#diff-462058254d5263a1f6ddcf9fcf6c6799a44bc37336ece0b942e7e85262cc1513L4-R8): Removed the `imghdr` module and added the `filetype` module for image type validation in the `save_image` method. [[1]](diffhunk://#diff-462058254d5263a1f6ddcf9fcf6c6799a44bc37336ece0b942e7e85262cc1513L4-R8) [[2]](diffhunk://#diff-462058254d5263a1f6ddcf9fcf6c6799a44bc37336ece0b942e7e85262cc1513L126-R127)
* [`better_bing_image_downloader/helperdownload.py`](diffhunk://#diff-200a991fdbd5ad2680e0e2622d1447bbf10b6bc09f7cd697d929f3439c0e2174L8-R12): Replaced `imghdr` with `filetype` for validating image types in the `download_image` function. [[1]](diffhunk://#diff-200a991fdbd5ad2680e0e2622d1447bbf10b6bc09f7cd697d929f3439c0e2174L8-R12) [[2]](diffhunk://#diff-200a991fdbd5ad2680e0e2622d1447bbf10b6bc09f7cd697d929f3439c0e2174L42-R50)

### Documentation and Version Update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114-R118): Added a changelog section describing the changes in version 1.1.3.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L8-R8): Updated the package version from 1.1.2 to 1.1.3.

#15 Should be solved
