### PR TITLE
fix: update headers to gzip and handle compressed Bing responses

### DIFF
--- a/better_bing_image_downloader/bing.py
+++ b/better_bing_image_downloader/bing.py
@@ -86,7 +86,7 @@ class Bing:
         return : None
         
     """
-    def __init__(self, query, limit, output_dir, adult, timeout, filter='', verbose=True, badsites=None, name='Image', max_workers=4, force_replace=False):
+    def __init__(self, query, limit, output_dir, adult, timeout, filter='', verbose=True, badsites=None, name='Image', max_workers=4, force_replace=False, mkt='en-US'):
         assert isinstance(limit, int), "limit must be integer"
         assert isinstance(timeout, int), "timeout must be integer"
         assert isinstance(max_workers, int), "max_workers must be integer"
@@ -101,6 +101,7 @@ class Bing:
         self.image_name = name
         self.timeout = timeout
         self.max_workers = max(1, min(max_workers, 16))  # Limit between 1 and 16
+        self.mkt = mkt
         
         self.seen = set()
         self.download_count = 0  # newly downloaded this run
@@ -258,6 +259,7 @@ class Bing:
                     + '&first=' + str(page_counter * page_size)
                     + '&count=' + str(page_size)
                     + '&adlt=' + self.adult
+                    + '&mkt=' + urllib.parse.quote_plus(self.mkt)
                     + '&qft=' + ('' if self.filter is None else self.get_filter(self.filter))
                 )
                 

--- a/better_bing_image_downloader/bing.py
+++ b/better_bing_image_downloader/bing.py
@@ -7,6 +7,7 @@ import re
 import logging
 import threading
 import hashlib
+import gzip
 from tqdm import tqdm
 import filetype
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -112,13 +113,16 @@ class Bing:
         self._hash_lock = threading.Lock()
         
         # Standard headers for HTTP requests
+        # NOTE: Accept-Encoding must include gzip so Bing returns the full compressed
+        # response. Without it, Bing now returns a severely truncated page with almost
+        # no image results (only 1 vs 35+ with gzip).
         self.headers = {
-            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11',
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
-            'Accept-Encoding': 'none',
-            'Accept-Language': 'en-US,en;q=0.8',
-            'Connection': 'keep-alive'
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Accept-Encoding': 'gzip, deflate',
+            'Connection': 'keep-alive',
+            'Referer': 'https://www.bing.com/',
         }
         
         # Ensure the output directory exists
@@ -259,7 +263,12 @@ class Bing:
                 
                 request = urllib.request.Request(request_url, None, headers=self.headers)
                 with urllib.request.urlopen(request, timeout=self.timeout) as response:
-                    html = response.read().decode('utf8')
+                    raw = response.read()
+                    content_encoding = response.headers.get('Content-Encoding', '')
+                    if content_encoding == 'gzip':
+                        html = gzip.decompress(raw).decode('utf8')
+                    else:
+                        html = raw.decode('utf8', errors='replace')
                 
                 if not html:
                     logging.info("[%] No more images are available")

--- a/better_bing_image_downloader/download.py
+++ b/better_bing_image_downloader/download.py
@@ -12,7 +12,7 @@ def downloader(
     query: str,
     limit: int = 100,
     output_dir: str = 'dataset',
-    adult_filter_off: bool = True,
+    adult_filter_off: bool = False,
     force_replace: bool = False,
     timeout: int = 60,
     image_filter: str = "",
@@ -20,6 +20,7 @@ def downloader(
     badsites: list = None,  # type: ignore[assignment]
     name: str = 'Image',
     max_workers: int = 4,
+    mkt: str = 'en-US',
     **kwargs  # backward compat
 ) -> int:
     """
@@ -29,7 +30,7 @@ def downloader(
     query (str): The search query.
     limit (int): The maximum number of images to download.
     output_dir (str): The directory to save the images in.
-    adult_filter_off (bool): Whether to turn off the adult filter.
+    adult_filter_off (bool): Whether to turn off the adult filter. Defaults to False (filter ON, moderate safe search).
     force_replace (bool): Whether to replace existing files.
     timeout (int): The timeout for the image download.
     image_filter (str): The filter to apply to the search results.
@@ -37,6 +38,7 @@ def downloader(
     badsites (list): List of bad sites to be excluded.
     name (str): The name of the images.
     max_workers (int): Maximum number of parallel download workers (default: 4).
+    mkt (str): Bing market code for language/region of results (default: 'en-US').
     """
     # Backward compatibility: accept old 'filter' keyword arg
     if 'filter' in kwargs:
@@ -49,7 +51,9 @@ def downloader(
         image_filter = kwargs.pop('filter')
 
     # Set adult filter setting
-    adult = 'off' if adult_filter_off else 'on'
+    # adult_filter_off=False (default) → 'moderate' (Bing's recommended safe search)
+    # adult_filter_off=True            → 'off'      (no filtering)
+    adult = 'off' if adult_filter_off else 'moderate'
 
     # Resolve mutable default
     badsites = badsites or []
@@ -90,7 +94,8 @@ def downloader(
             badsites=badsites, 
             name=name,
             max_workers=max_workers,
-            force_replace=force_replace
+            force_replace=force_replace,
+            mkt=mkt
         )
         # Type annotation is ignored in runtime
         bing.download_callback = update_progress_bar  # type: ignore
@@ -135,6 +140,7 @@ def main():
     parser.add_argument('-b', '--bad-sites', nargs='*', default=[], help='List of bad sites to be excluded.')
     parser.add_argument('-n', '--name', type=str, default='Image', help='The name of the images.')
     parser.add_argument('-w', '--workers', type=int, default=4, help='Maximum number of parallel download workers.')
+    parser.add_argument('-m', '--mkt', type=str, default='en-US', help='Bing market code for language/region of results (e.g. en-US, de-DE). Default: en-US.')
 
     args = parser.parse_args()
     logging_level = logging.INFO if args.verbose else logging.WARNING
@@ -151,7 +157,8 @@ def main():
         args.verbose,
         args.bad_sites,
         args.name,
-        args.workers
+        args.workers,
+        args.mkt
     )
 
 


### PR DESCRIPTION
## Problem

Users were getting irrelevant, repeated, and occasionally inappropriate/adult images. Two separate root causes identified.

---

## Fix 1: Stale headers causing truncated Bing responses

The old headers used `Accept-Encoding: none` and a 2012-era Chrome 23 User-Agent. Bing now returns a severely truncated response (~47 KB, **1 image**) to requests without gzip support. With gzip enabled, the full response (~340 KB, **35–47 images**) is returned.

**Changes:**
- Update `User-Agent` to Chrome 124 on Windows
- Change `Accept-Encoding` from `'none'` → `'gzip, deflate'`
- Add `Referer: https://www.bing.com/` header
- Decompress gzip responses in `run()` using stdlib `gzip`

---

## Fix 2: Safe search disabled by default + non-English results

**Adult filter:** `adult_filter_off` defaulted to `True`, which explicitly sent `adlt=off` to Bing — disabling Bing's own default safe search. Changed default to `False` (sends `adlt=moderate`), which is what the Bing browser UI uses.

**Non-English results:** No market code was sent, so Bing geo-detected the server's location and could return results with non-English text (e.g. Chinese). Added `mkt` parameter (default `en-US`) to pin results to English.

**Changes:**
- `adult_filter_off` default: `True` → `False` (safe search **on** by default)
- Adult mapping: `'on'` → `'moderate'` (matches Bing browser default)
- Add `mkt` parameter to `Bing` and `downloader()` (default: `'en-US'`)
- Add `-m`/`--mkt` CLI flag

> **Breaking change:** `adult_filter_off` now defaults to `False`. Callers relying on the old default (no filtering) must pass `adult_filter_off=True` explicitly.

---

## Testing

- Old headers → 1 link returned per page; new headers → 47 links for same query
- `adult_filter_off=False` → `adlt=moderate` in request URL (verified)
- `mkt=en-US` appears in request URL (verified)
- CLI `--help` shows `-m/--mkt` flag