### PR TITLE
fix: include manifest_path in Result.__repr__ (issue #34)

### DIFF
--- a/better_bing_image_downloader/results.py
+++ b/better_bing_image_downloader/results.py
@@ -175,8 +175,10 @@ class Result:
         if self.cancelled:
             flags.append("cancelled")
         flag_str = f", flags={flags}" if flags else ""
+        manifest_repr = self.manifest_path if self.manifest_path is not None else "no manifest"
         return (
             f"Result(query={self.query!r}, engine={self.engine!r}, "
             f"count={self.count}, skipped={self.skipped}, "
-            f"errors={len(self.errors)}{flag_str})"
+            f"errors={len(self.errors)}{flag_str}, "
+            f"manifest_path={manifest_repr!r})"
         )

--- a/tests/test_v3_5_0_manifest.py
+++ b/tests/test_v3_5_0_manifest.py
@@ -724,3 +724,55 @@ def test_legacy_downloader_function_supports_manifest(tmp_path: Path) -> None:
     assert captured["manifest_fields"] == ["url", "md5"]
     # Legacy downloader() returns int.
     assert isinstance(result_count, int)
+
+
+# --- Group: Result.__repr__ includes manifest_path (issue #34) ---
+
+
+def test_result_repr_includes_manifest_path_when_set(tmp_path: Path) -> None:
+    """Result.__repr__ includes manifest_path when a manifest was written."""
+    from better_bing_image_downloader import Result
+
+    r = Result(
+        query="cats",
+        engine="bing",
+        output_dir=tmp_path,
+        manifest_path=str(tmp_path / "manifest.jsonl"),
+    )
+    text = repr(r)
+    assert "manifest.jsonl" in text
+    assert "manifest_path" in text
+    assert str(tmp_path / "manifest.jsonl") in text
+
+
+def test_result_repr_includes_no_manifest_sentinel_when_none(tmp_path: Path) -> None:
+    """Result.__repr__ shows 'no manifest' when manifest_path is None."""
+    from better_bing_image_downloader import Result
+
+    r = Result(
+        query="cats",
+        engine="bing",
+        output_dir=tmp_path,
+    )
+    text = repr(r)
+    assert "no manifest" in text
+    assert "manifest_path" in text
+
+
+def test_result_repr_preserves_existing_flags_ordering(tmp_path: Path) -> None:
+    """Adding manifest_path must not disturb the existing repr format."""
+    from better_bing_image_downloader import Result
+
+    r = Result(
+        query="cats",
+        engine="bing",
+        output_dir=tmp_path,
+        no_results_found=True,
+        cancelled=True,
+        manifest_path=str(tmp_path / "m.jsonl"),
+    )
+    text = repr(r)
+    # The existing flags= list and trailing manifest_path should both
+    # still be present, in the documented order.
+    assert "flags=['no_results_found', 'cancelled']" in text
+    assert text.endswith("manifest_path='" + str(tmp_path / "m.jsonl") + "')")


### PR DESCRIPTION
Closes #34

Result.__repr__ (better_bing_image_downloader/results.py) was missing the manifest_path field, so a logged Result gave no visibility into whether a manifest was written or where.

**Before:**
```
Result(query='cat', engine='bing', count=10, skipped=0, errors=0, flags=['cancelled'])
```

**After (with manifest):**
```
Result(query='cat', engine='bing', count=10, skipped=0, errors=0, flags=['cancelled'], manifest_path='/tmp/cats/manifest.jsonl')
```

**After (no manifest):**
```
Result(query='cat', engine='bing', count=0, skipped=0, errors=0, manifest_path='no manifest')
```

### Changes
- Update `Result.__repr__` in `better_bing_image_downloader/results.py` to include `manifest_path` (or `'no manifest'` if `None`). Placed after the existing `flags=...` segment so the legacy format is preserved.
- Add 3 tests in `tests/test_v3_5_0_manifest.py`:
  - `test_result_repr_includes_manifest_path_when_set`
  - `test_result_repr_includes_no_manifest_sentinel_when_none`
  - `test_result_repr_preserves_existing_flags_ordering`

### Verification
```
$ python3 -m pytest tests/test_v3_5_0_manifest.py -k repr -v
tests/test_v3_5_0_manifest.py::test_result_repr_includes_manifest_path_when_set PASSED
tests/test_v3_5_0_manifest.py::test_result_repr_includes_no_manifest_sentinel_when_none PASSED
tests/test_v3_5_0_manifest.py::test_result_repr_preserves_existing_flags_ordering PASSED

$ python3 -m ruff check better_bing_image_downloader/results.py tests/test_v3_5_0_manifest.py
All checks passed!
```

No behavior change for any other code path.

— Sent via @AmSach bot