### PR TITLE
feat(downloader): add min_dimension filter for search()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`min_dimension` filter** for `Downloader.search()` / `search_async()`.
+  Images smaller than `min_dimension` pixels on either side are
+  skipped before being saved — useful for ML training-data
+  preparation, where thumbnails are noise. Dimensions are read
+  directly from PNG, JPEG, GIF, BMP, and WEBP headers (no new
+  dependency); formats we can't parse (e.g. TIFF) are never
+  filtered.
+- New `BelowMinDimension` exception (subclass of `ImageSaveError`,
+  so `except ImageSaveError` still catches it).
+- Skips from the new filter are recorded in the manifest as
+  `status="skipped"`, `error="BelowMinDimension"`, and counted in
+  `Result.skipped` — not `Result.errors` / `on_error`, since a
+  too-small image is an intentional filter outcome, not a failure.
+- 13 new tests in `tests/test_v3_6_0_features.py`.
+
 ## [3.5.1] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -343,6 +343,35 @@ CLI equivalent:
 bbid --manifest --manifest-fields index,status,url,md5 "red panda"
 ```
 
+#### Minimum dimension filter (v3.6.0+)
+
+For ML training data, thumbnails are noise. Pass `min_dimension` to
+skip any image smaller than `N` pixels on either side before it's
+saved:
+
+```python
+from better_bing_image_downloader import Downloader
+
+dl = Downloader()
+result = dl.search(
+    "red panda", limit=100, engine="duckduckgo",
+    min_dimension=512,  # reject anything under 512x512
+)
+print(f"Saved {result.count} images, skipped {result.skipped} too-small ones")
+```
+
+Skipped images don't count against `result.images` or
+`result.errors` — `result.skipped` is incremented instead, since a
+too-small image is an intentional filter outcome, not a failure.
+With `manifest=True`, each skip is recorded as
+`{"status": "skipped", "error": "BelowMinDimension", ...}` so
+downstream tooling can audit exactly what was filtered and why.
+
+Dimensions are read from PNG, JPEG, GIF, BMP, and WEBP headers
+directly (no extra dependency). Formats we can't parse (e.g. TIFF)
+are never filtered — an unmeasurable image is always kept rather
+than dropped on a guess.
+
 ### Resume behaviour
 
 By default (`force_replace=False`), re-running the same query skips already-downloaded files and downloads only what's missing:

--- a/better_bing_image_downloader/__init__.py
+++ b/better_bing_image_downloader/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from .base import (
+    BelowMinDimension,
     DuplicateImageError,
     ImageEngine,
     ImageSaveError,
@@ -17,6 +18,7 @@ from .results import ImageResult, Result
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
+    "BelowMinDimension",
     "Bing",
     "CancelToken",
     "DEFAULT_MANIFEST_FIELDS",

--- a/better_bing_image_downloader/base.py
+++ b/better_bing_image_downloader/base.py
@@ -28,6 +28,7 @@ __all__ = [
     "InvalidImageError",
     "DuplicateImageError",
     "WriteError",
+    "BelowMinDimension",
     "MAX_FUTURE_TIMEOUT",
     "VALID_IMAGE_EXTENSIONS",
 ]
@@ -104,6 +105,32 @@ class WriteError(ImageSaveError):
         super().__init__(reason="write_failed", url=url, message=message)
 
 
+class BelowMinDimension(ImageSaveError):
+    """The fetched image's width or height is below ``min_dimension`` (v3.6.0+).
+
+    Raised by ``_save_image_raising`` when ``self.min_dimension`` is set
+    and the downloaded image is smaller than that threshold on either
+    side. ``Downloader.search`` treats this differently from the other
+    ``ImageSaveError`` subclasses: it's recorded in the manifest as a
+    ``"skipped"`` record (not an ``"error"``) and counted in
+    ``Result.skipped`` rather than ``Result.errors``, since a too-small
+    image is an intentional filter outcome, not a failure.
+    """
+
+    def __init__(
+        self, url: str, width: int, height: int, min_dimension: int, message: str = ""
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.min_dimension = min_dimension
+        if not message:
+            message = (
+                f"image below minimum dimension at {url!r}: "
+                f"{width}x{height} < {min_dimension}px"
+            )
+        super().__init__(reason="below_min_dimension", url=url, message=message)
+
+
 # Extensions we accept when renaming downloaded images. Bing sometimes
 # returns URLs without an extension, so we use this set for the fallback.
 VALID_IMAGE_EXTENSIONS = {
@@ -135,6 +162,107 @@ DEFAULT_HEADERS = {
 }
 
 
+def _read_jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Walk JPEG markers looking for a Start-Of-Frame (SOFn) segment."""
+    pos = 2  # skip the SOI marker (0xFFD8)
+    length = len(data)
+    while pos + 4 <= length:
+        if data[pos] != 0xFF:
+            pos += 1
+            continue
+        marker = data[pos + 1]
+        # Standalone markers (no length field, no payload).
+        if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+            pos += 2
+            continue
+        seg_len = int.from_bytes(data[pos + 2 : pos + 4], "big")
+        is_sof = 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC)
+        if is_sof:
+            if pos + 9 > length:
+                return None
+            height = int.from_bytes(data[pos + 5 : pos + 7], "big")
+            width = int.from_bytes(data[pos + 7 : pos + 9], "big")
+            return width, height
+        pos += 2 + seg_len
+    return None
+
+
+def _read_webp_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Parse a WEBP file's VP8 / VP8L / VP8X chunk header for canvas dimensions."""
+    chunk = data[12:16]
+    payload = data[20:]
+    if chunk == b"VP8X":
+        if len(payload) < 10:
+            return None
+        width = int.from_bytes(payload[4:7], "little") + 1
+        height = int.from_bytes(payload[7:10], "little") + 1
+        return width, height
+    if chunk == b"VP8L":
+        if len(payload) < 5 or payload[0] != 0x2F:
+            return None
+        bits = int.from_bytes(payload[1:5], "little")
+        width = (bits & 0x3FFF) + 1
+        height = ((bits >> 14) & 0x3FFF) + 1
+        return width, height
+    if chunk == b"VP8 ":
+        # 3-byte frame tag + 3-byte start code (0x9d 0x01 0x2a), then
+        # width/height as 16-bit little-endian (low 14 bits = size).
+        if len(payload) < 10 or payload[3:6] != b"\x9d\x01\x2a":
+            return None
+        width = int.from_bytes(payload[6:8], "little") & 0x3FFF
+        height = int.from_bytes(payload[8:10], "little") & 0x3FFF
+        return width, height
+    return None
+
+
+def _read_image_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Best-effort ``(width, height)`` from raw image bytes (v3.6.0+).
+
+    Parses container headers directly for PNG, GIF, BMP, JPEG, and WEBP
+    without decoding pixel data, so it's cheap to run on every
+    downloaded image. Returns ``None`` for formats we don't parse
+    (e.g. TIFF) or on any malformed/truncated input. Callers must
+    treat ``None`` as "dimensions unknown, don't filter" rather than
+    "image too small" — we'd rather let an unmeasurable image through
+    than drop a valid one.
+    """
+    try:
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            # IHDR is always the first chunk: 4-byte length, "IHDR",
+            # then 4-byte width and 4-byte height (big-endian).
+            if len(data) >= 24 and data[12:16] == b"IHDR":
+                width = int.from_bytes(data[16:20], "big")
+                height = int.from_bytes(data[20:24], "big")
+                return width, height
+            return None
+
+        if data[:6] in (b"GIF87a", b"GIF89a"):
+            if len(data) >= 10:
+                width = int.from_bytes(data[6:8], "little")
+                height = int.from_bytes(data[8:10], "little")
+                return width, height
+            return None
+
+        if data[:2] == b"BM":
+            # BITMAPFILEHEADER (14 bytes) then BITMAPINFOHEADER width
+            # (offset 18) / height (offset 22) as little-endian int32.
+            # Height may be negative for top-down bitmaps.
+            if len(data) >= 26:
+                width = int.from_bytes(data[18:22], "little", signed=True)
+                height = int.from_bytes(data[22:26], "little", signed=True)
+                return abs(width), abs(height)
+            return None
+
+        if data[:2] == b"\xff\xd8":
+            return _read_jpeg_dimensions(data)
+
+        if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return _read_webp_dimensions(data)
+    except Exception:  # noqa: BLE001 - dimension sniffing must never crash a download
+        return None
+    return None
+
+
 class ImageEngine(ABC):
     """Base class for image search engine scrapers.
 
@@ -156,6 +284,7 @@ class ImageEngine(ABC):
         max_workers: int = 4,
         force_replace: bool = False,
         cancel=None,
+        min_dimension: int | None = None,
     ):
         # Abstract base class — subclasses MUST override ``run()``.
         # The abstractmethod below is what makes
@@ -181,6 +310,13 @@ class ImageEngine(ABC):
         # and image downloads. We don't import CancelToken here to
         # avoid a circular import; the type is duck-typed.
         self.cancel = cancel
+        # ``min_dimension`` (v3.6.0+): minimum width/height in pixels an
+        # image must have to be kept. ``None`` (the default) disables
+        # the check entirely. Bing/DuckDuckGo don't accept this in
+        # their own constructors; ``Downloader.search`` sets it
+        # directly on the engine instance after construction (see
+        # downloader.py), the same way it monkey-patches save_image.
+        self.min_dimension: int | None = min_dimension
 
         self.seen: set[str] = set()
         self.download_count = 0  # newly downloaded this run
@@ -281,6 +417,9 @@ class ImageEngine(ABC):
             The HTTP fetch failed (timeout, 5xx, DNS error, etc.).
         InvalidImageError
             The fetched bytes don't look like an image.
+        BelowMinDimension
+            ``self.min_dimension`` is set and the image's width or
+            height is smaller than it (v3.6.0+).
         DuplicateImageError
             An image with the same MD5 hash has already been saved
             this run.
@@ -297,6 +436,18 @@ class ImageEngine(ABC):
         kind = filetype.guess(image)
         if not kind or not kind.mime.startswith("image/"):
             raise InvalidImageError(url=link)
+
+        if self.min_dimension is not None:
+            dimensions = _read_image_dimensions(image)
+            if dimensions is not None:
+                width, height = dimensions
+                if width < self.min_dimension or height < self.min_dimension:
+                    raise BelowMinDimension(
+                        url=link,
+                        width=width,
+                        height=height,
+                        min_dimension=self.min_dimension,
+                    )
 
         file_hash = hashlib.md5(image).hexdigest()
         with self._hash_lock:

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -48,6 +48,7 @@ __all__ = [
     "InvalidImageError",
     "DuplicateImageError",
     "WriteError",
+    "BelowMinDimension",
     "CancelToken",
     "ManifestWriter",
     "DEFAULT_MANIFEST_FIELDS",
@@ -59,6 +60,7 @@ __all__ = [
 # etc. The actual class definitions live in base.py to avoid a
 # circular import (base.py -> downloader.py -> base.py).
 from .base import (  # noqa: E402
+    BelowMinDimension,
     DuplicateImageError,
     ImageSaveError,
     InvalidImageError,
@@ -296,6 +298,7 @@ class Downloader:
         manifest_path: str | os.PathLike | None = None,
         manifest_fields: list[str] | None = None,
         manifest_flush_every: int = 1,
+        min_dimension: int | None = None,
     ) -> Result:
         """Run a search and return a :class:`Result`.
 
@@ -336,6 +339,16 @@ class Downloader:
             default ``1`` is crash-safe; higher values trade crash
             safety for throughput on slow disks. ``close()`` always
             flushes regardless of this value. Default: ``1``.
+        min_dimension : int | None
+            Minimum width and height in pixels (v3.6.0+). If set, any
+            downloaded image smaller than this on either side is
+            skipped: it does not count toward :attr:`Result.images`
+            or :attr:`Result.errors`, is recorded in the manifest (if
+            ``manifest=True``) as ``status="skipped"``,
+            ``error="BelowMinDimension"``, and is counted in
+            :attr:`Result.skipped`. Images in formats we can't
+            measure (e.g. TIFF) are not filtered. Default ``None``
+            (no filtering).
         """
         image_dir = Path(output_dir) / query
         image_dir.mkdir(parents=True, exist_ok=True)
@@ -397,6 +410,13 @@ class Downloader:
             force_replace=force_replace,
             **engine_kwargs,
         )
+        # ``min_dimension`` (v3.6.0+) isn't part of Bing's or
+        # DuckDuckGo's own constructor signature, so it can't go
+        # through ``engine_kwargs`` above without breaking those
+        # classes. Set it directly on the instance instead — the same
+        # pattern used below for the save_image/download_image
+        # monkey-patches.
+        engine_obj.min_dimension = min_dimension
 
         # Wire hooks: the engine records every successful save into
         # ``manifest`` and increments ``download_count`` / ``_slots_used``.
@@ -424,6 +444,12 @@ class Downloader:
         # actually invoked (not skipped due to resume). Useful for
         # debugging.
         save_attempts = 0
+        # ``min_dimension_skips`` (v3.6.0+) counts images rejected by
+        # the ``min_dimension`` filter. Unlike other ``ImageSaveError``
+        # subclasses, these don't go into ``errors`` — they're an
+        # intentional filter outcome, not a failure — so they need
+        # their own counter to feed into ``Result.skipped`` below.
+        min_dimension_skips = 0
         # ``progress_state`` tracks timing samples for ETA
         # computation. We need at least 2 samples (one for the
         # previous download, one for the current) to extrapolate.
@@ -447,7 +473,7 @@ class Downloader:
         original_download = engine_obj.download_image
 
         def save_with_hooks(link: str, file_path) -> bool:
-            nonlocal save_attempts
+            nonlocal save_attempts, min_dimension_skips
             save_attempts += 1
             try:
                 # ``_save_image_raising`` returns the MD5 hex digest
@@ -455,6 +481,23 @@ class Downloader:
                 # ``save_image`` wrapper does not return it; we
                 # rely on the raising variant here.
                 file_md5 = original_save_raising(link, file_path)
+            except BelowMinDimension as exc:
+                # v3.6.0+: a too-small image is an intentional filter
+                # outcome, not a failure — unlike the other
+                # ImageSaveError subclasses below, it does NOT go
+                # into Result.errors or fire on_error. It's recorded
+                # as a manifest "skip" and counted in Result.skipped.
+                min_dimension_skips += 1
+                if self._manifest_writer is not None:
+                    self._append_manifest_record(
+                        status="skipped",
+                        url=link,
+                        file_path=None,
+                        md5=None,
+                        error=exc,
+                        engine_obj=engine_obj,
+                    )
+                return False
             except ImageSaveError as exc:
                 # Typed save failure (v3.4.0+). Surface via on_error
                 # and Result.errors.
@@ -582,7 +625,11 @@ class Downloader:
         # incremented ``download_count`` without ``_slots_used`` (or
         # vice versa), the subtraction can go negative. We don't
         # want a nonsensical negative count in the result.
-        skipped = max(0, engine_obj._slots_used - engine_obj.download_count)
+        # ``min_dimension_skips`` (v3.6.0+) is added on top: those
+        # images never touch ``_slots_used``/``download_count`` at
+        # all (the engine just moves on to the next candidate), so
+        # they need to be folded in separately.
+        skipped = max(0, engine_obj._slots_used - engine_obj.download_count) + min_dimension_skips
 
         result = Result(
             query=query,
@@ -685,6 +732,7 @@ class Downloader:
         manifest_path: str | os.PathLike | None = None,
         manifest_fields: list[str] | None = None,
         manifest_flush_every: int = 1,
+        min_dimension: int | None = None,
     ) -> Result:
         """Async wrapper around :meth:`search`.
 
@@ -738,6 +786,7 @@ class Downloader:
             manifest_path=manifest_path,
             manifest_fields=manifest_fields,
             manifest_flush_every=manifest_flush_every,
+            min_dimension=min_dimension,
         )
 
 

--- a/better_bing_image_downloader/results.py
+++ b/better_bing_image_downloader/results.py
@@ -70,8 +70,10 @@ class Result:
         Every image that was newly saved by this run (does not include
         files that were already on disk from a previous run).
     skipped : int
-        Number of files that were skipped because they already existed
-        (``force_replace=False`` and a file with that index was present).
+        Number of files that were skipped: either because they already
+        existed (``force_replace=False`` and a file with that index
+        was present) or, as of v3.6.0, because they were smaller than
+        ``min_dimension`` on either side.
     errors : list[tuple[str, BaseException]]
         ``(url, exception)`` pairs for each download that failed.
     no_results_found : bool

--- a/tests/test_v3_6_0_features.py
+++ b/tests/test_v3_6_0_features.py
@@ -1,0 +1,307 @@
+"""Tests for v3.6.0's ``min_dimension`` filter.
+
+One new thing in 3.6.0: ``Downloader.search(min_dimension=N)`` skips
+any downloaded image smaller than ``N`` pixels on either side, so ML
+training-data pipelines don't have to filter thumbnails out of the
+manifest themselves.
+
+- New typed exception: ``BelowMinDimension`` (a subclass of
+  ``ImageSaveError``, so ``except ImageSaveError`` still catches it).
+- New ``Downloader.search`` / ``search_async`` parameter:
+  ``min_dimension``.
+- Skips are recorded in the manifest as ``status="skipped"``,
+  ``error="BelowMinDimension"``, and counted in ``Result.skipped``
+  (NOT ``Result.errors`` — a too-small image is an intentional filter
+  outcome, not a failure).
+- Images in formats we can't measure (e.g. TIFF) are never filtered.
+
+All tests follow the project's existing patterns: mock
+``ImageEngine._http_get`` at the module-attribute boundary, no real
+network, stub engines registered against a ``Downloader`` instance.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+from unittest.mock import patch
+
+from better_bing_image_downloader import BelowMinDimension, Downloader, ImageEngine, ImageSaveError
+
+# --- Byte builders for synthetic images (header-only; no real pixel data) ---
+
+
+def _make_png(width: int, height: int) -> bytes:
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunk = struct.pack(">I", len(ihdr_data)) + b"IHDR" + ihdr_data + b"\x00\x00\x00\x00"
+    return sig + chunk
+
+
+def _make_gif(width: int, height: int) -> bytes:
+    return b"GIF89a" + struct.pack("<HH", width, height) + b"\x00" * 4
+
+
+def _make_bmp(width: int, height: int) -> bytes:
+    header = b"BM" + b"\x00" * 8 + b"\x00\x00\x00\x00"
+    dib = struct.pack("<IiiHH", 40, width, height, 1, 24) + b"\x00" * 20
+    return header + dib
+
+
+def _make_jpeg(width: int, height: int) -> bytes:
+    soi = b"\xff\xd8"
+    app0 = (
+        b"\xff\xe0"
+        + struct.pack(">H", 16)
+        + b"JFIF\x00\x01\x01\x00"
+        + struct.pack(">HH", 1, 1)
+        + b"\x00\x00"
+    )
+    sof0_payload = (
+        struct.pack(">BHHB", 8, height, width, 3)
+        + b"\x01\x11\x00"
+        + b"\x02\x11\x01"
+        + b"\x03\x11\x01"
+    )
+    sof0 = b"\xff\xc0" + struct.pack(">H", len(sof0_payload) + 2) + sof0_payload
+    return soi + app0 + sof0 + b"\xff\xd9"
+
+
+def _make_webp_vp8x(width: int, height: int) -> bytes:
+    payload = (
+        b"\x00\x00\x00\x00" + (width - 1).to_bytes(3, "little") + (height - 1).to_bytes(3, "little")
+    )
+    chunk = b"VP8X" + struct.pack("<I", len(payload)) + payload
+    riff_payload = b"WEBP" + chunk
+    return b"RIFF" + struct.pack("<I", len(riff_payload)) + riff_payload
+
+
+def _make_tiff() -> bytes:
+    # Recognized as image/tiff by ``filetype``, but our dimension
+    # reader doesn't parse TIFF's IFD structure, so this always
+    # yields ``None`` from ``_read_image_dimensions``.
+    return b"II*\x00" + b"\x00" * 20
+
+
+# --- Group A: BelowMinDimension exception (1 test) ---
+
+
+def test_below_min_dimension_is_image_save_error_subclass() -> None:
+    """BelowMinDimension is an ImageSaveError (Liskov substitution)."""
+    assert issubclass(BelowMinDimension, ImageSaveError)
+    exc = BelowMinDimension(url="https://x/a.jpg", width=10, height=10, min_dimension=50)
+    assert isinstance(exc, ImageSaveError)
+    assert exc.width == 10
+    assert exc.height == 10
+    assert exc.min_dimension == 50
+
+
+# --- Group B: _read_image_dimensions unit tests (6 tests) ---
+
+
+def test_read_image_dimensions_png() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_png(800, 600)) == (800, 600)
+
+
+def test_read_image_dimensions_gif() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_gif(320, 240)) == (320, 240)
+
+
+def test_read_image_dimensions_bmp() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_bmp(640, 480)) == (640, 480)
+
+
+def test_read_image_dimensions_jpeg() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_jpeg(800, 600)) == (800, 600)
+
+
+def test_read_image_dimensions_webp() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_webp_vp8x(800, 600)) == (800, 600)
+
+
+def test_read_image_dimensions_unknown_or_malformed_returns_none() -> None:
+    from better_bing_image_downloader.base import _read_image_dimensions
+
+    assert _read_image_dimensions(_make_tiff()) is None
+    assert _read_image_dimensions(b"not an image at all") is None
+    assert _read_image_dimensions(b"") is None
+
+
+# --- Group C: Downloader.search(min_dimension=...) integration (6 tests) ---
+
+
+def _make_dimension_stub() -> type[ImageEngine]:
+    """A stub engine that downloads two URLs: 'small' and 'large'."""
+
+    class DimensionStub(ImageEngine):
+        def run(self) -> None:
+            self.download_image("https://example.test/small.png", 1)
+            self.download_image("https://example.test/large.png", 2)
+
+    return DimensionStub
+
+
+def test_search_min_dimension_none_is_noop(tmp_path: Path) -> None:
+    """Without min_dimension, both a tiny and a large image are saved."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_dimension_stub())
+
+    def fake_http_get(self, url, headers=None):
+        if "small" in url:
+            return _make_png(10, 10)
+        return _make_png(800, 600)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = dl.search("cat", limit=2, engine="stub", output_dir=tmp_path)
+
+    assert result.count == 2
+    assert result.skipped == 0
+    assert result.errors == []
+
+
+def test_search_min_dimension_skips_small_image(tmp_path: Path) -> None:
+    """An image below min_dimension is skipped, not saved, not an error."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_dimension_stub())
+
+    error_calls = []
+    dl.on_error = lambda url, exc: error_calls.append((url, exc))
+
+    def fake_http_get(self, url, headers=None):
+        if "small" in url:
+            return _make_png(10, 10)
+        return _make_png(800, 600)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = dl.search("cat", limit=2, engine="stub", output_dir=tmp_path, min_dimension=200)
+
+    assert result.count == 1
+    assert result.images[0].source_url == "https://example.test/large.png"
+    assert result.skipped == 1
+    # A min_dimension skip is NOT an error: no Result.errors entry, no
+    # on_error call.
+    assert result.errors == []
+    assert error_calls == []
+
+
+def test_search_min_dimension_threshold_is_strict_less_than(tmp_path: Path) -> None:
+    """An image exactly at min_dimension passes; one pixel under is skipped."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+
+    class ExactStub(ImageEngine):
+        def run(self) -> None:
+            self.download_image("https://example.test/exact.png", 1)
+            self.download_image("https://example.test/under.png", 2)
+
+    dl.register("stub", ExactStub)
+
+    def fake_http_get(self, url, headers=None):
+        if "exact" in url:
+            return _make_png(200, 200)
+        return _make_png(199, 200)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = dl.search("cat", limit=2, engine="stub", output_dir=tmp_path, min_dimension=200)
+
+    assert result.count == 1
+    assert result.images[0].source_url == "https://example.test/exact.png"
+    assert result.skipped == 1
+
+
+def test_search_min_dimension_unmeasurable_format_not_filtered(tmp_path: Path) -> None:
+    """A format we can't read dimensions for (TIFF) is never filtered."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+
+    class TiffStub(ImageEngine):
+        def run(self) -> None:
+            self.download_image("https://example.test/a.tiff", 1)
+
+    dl.register("stub", TiffStub)
+
+    def fake_http_get(self, url, headers=None):
+        return _make_tiff()
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        # A huge threshold would reject any real image this small,
+        # but since we can't measure TIFF, it must still be saved.
+        result = dl.search(
+            "cat", limit=1, engine="stub", output_dir=tmp_path, min_dimension=999_999
+        )
+
+    assert result.count == 1
+    assert result.skipped == 0
+
+
+def test_search_min_dimension_manifest_records_skip(tmp_path: Path) -> None:
+    """manifest=True records the skip as status='skipped', error='BelowMinDimension'."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_dimension_stub())
+
+    def fake_http_get(self, url, headers=None):
+        if "small" in url:
+            return _make_png(10, 10)
+        return _make_png(800, 600)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = dl.search(
+            "cat",
+            limit=2,
+            engine="stub",
+            output_dir=tmp_path,
+            min_dimension=200,
+            manifest=True,
+        )
+
+    lines = Path(result.manifest_path).read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in lines]
+    assert len(records) == 2
+    statuses = {r["url"]: r["status"] for r in records}
+    errors = {r["url"]: r["error"] for r in records}
+    assert statuses["https://example.test/small.png"] == "skipped"
+    assert errors["https://example.test/small.png"] == "BelowMinDimension"
+    assert statuses["https://example.test/large.png"] == "ok"
+    assert errors["https://example.test/large.png"] is None
+
+
+def test_search_async_honors_min_dimension(tmp_path: Path) -> None:
+    """search_async forwards min_dimension the same way search() does."""
+    import asyncio
+
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_dimension_stub())
+
+    def fake_http_get(self, url, headers=None):
+        if "small" in url:
+            return _make_png(10, 10)
+        return _make_png(800, 600)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = asyncio.run(
+            dl.search_async("cat", limit=2, engine="stub", output_dir=tmp_path, min_dimension=200)
+        )
+
+    assert result.count == 1
+    assert result.skipped == 1


### PR DESCRIPTION
Introduces a new min_dimension parameter in Downloader.search() and search_async() to skip images smaller than the given size on either side, useful for ML training-data preparation where thumbnails are noise. Adds a new BelowMinDimension exception (subclass of ImageSaveError), records skips in the manifest as
status="skipped"/error="BelowMinDimension", and counts them in Result.skipped rather than Result.errors, since a too-small image is an intentional filter outcome, not a failure.

- New min_dimension filter for image downloads.
- BelowMinDimension exception for handling skipped images.
- Manifest records for skipped images with appropriate status.
- 13 new tests in tests/test_v3_6_0_features.py.

Closes #31