### PR TITLE
docs: document commit-signing requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,22 @@ line stays under 72 characters; the body, if any, is wrapped at 72.
    gh pr create --fill
    ```
 
+5.1. **Sign your commits.** This repository's `main` branch requires
+   GPG- or SSH-signed commits (`required_signatures: true`). Before
+   you push:
+
+   - Configure git signing:
+     ```bash
+     git config commit.gpgsign true
+     git config user.signingkey <KEY_ID>
+     ```
+
+   - Upload your public signing key in
+     GitHub account settings: <https://github.com/settings/keys>
+
+   Commits that GitHub marks as `unknown_key` are treated as unsigned by
+   branch protection and will block merge.
+
 6. The maintainer will review and may request changes. Squash-merge is
    the default.
 


### PR DESCRIPTION
## Summary
Added contributor guidance for repository branch protection around signed commits in `CONTRIBUTING.md`.

## Linked issue
Closes #39

## Changes
- Added a new step in the pull request process to explain that `main` requires signed commits.
- Included local `git` signing configuration steps and GitHub key upload guidance.
- Documented that `unknown_key` signatures are treated as unsigned and can block merge.

## Validation
- `pytest` (from repo root): failed during test collection because optional deps are missing in this environment (`filetype` module not installed).
- `pre-commit` is not installed in this environment.
