### PR TITLE
Align embeddable verbose defaults

### DIFF
--- a/better_bing_image_downloader/base.py
+++ b/better_bing_image_downloader/base.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import filetype
 
 __all__ = [
+    "DEFAULT_VERBOSE",
     "ImageEngine",
     "ImageSaveError",
     "NetworkError",
@@ -134,6 +135,8 @@ DEFAULT_HEADERS = {
     "Accept-Encoding": "gzip, deflate",
 }
 
+DEFAULT_VERBOSE = False
+
 
 class ImageEngine(ABC):
     """Base class for image search engine scrapers.
@@ -150,7 +153,7 @@ class ImageEngine(ABC):
         limit: int,
         output_dir,
         timeout: int = 60,
-        verbose: bool = True,
+        verbose: bool = DEFAULT_VERBOSE,
         badsites=None,
         name: str = "Image",
         max_workers: int = 4,

--- a/better_bing_image_downloader/bing.py
+++ b/better_bing_image_downloader/bing.py
@@ -15,7 +15,7 @@ import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from .base import MAX_FUTURE_TIMEOUT, ImageEngine
+from .base import DEFAULT_VERBOSE, MAX_FUTURE_TIMEOUT, ImageEngine
 
 __all__ = ["Bing"]
 
@@ -66,7 +66,7 @@ class Bing(ImageEngine):
         adult: str = "moderate",
         timeout: int = 60,
         filter: str = "",
-        verbose: bool = True,
+        verbose: bool = DEFAULT_VERBOSE,
         badsites=None,
         name: str = "Image",
         max_workers: int = 4,

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
 
-from .base import ImageEngine
+from .base import DEFAULT_VERBOSE, ImageEngine
 from .bing import Bing
 from .duckduckgo import DuckDuckGo
 from .manifest import DEFAULT_MANIFEST_FIELDS, ManifestWriter
@@ -285,7 +285,7 @@ class Downloader:
         max_workers: int = 4,
         force_replace: bool = False,
         timeout: int = 60,
-        verbose: bool = False,
+        verbose: bool = DEFAULT_VERBOSE,
         image_filter: str = "",
         mkt: str = "en-US",
         ddg_safe_search: str = "moderate",
@@ -674,7 +674,7 @@ class Downloader:
         max_workers: int = 4,
         force_replace: bool = False,
         timeout: int = 60,
-        verbose: bool = False,
+        verbose: bool = DEFAULT_VERBOSE,
         image_filter: str = "",
         mkt: str = "en-US",
         ddg_safe_search: str = "moderate",

--- a/better_bing_image_downloader/duckduckgo.py
+++ b/better_bing_image_downloader/duckduckgo.py
@@ -36,7 +36,7 @@ except ImportError:  # pragma: no cover
     brotli = None
     _HAS_BROTLI = False
 
-from .base import MAX_FUTURE_TIMEOUT, ImageEngine
+from .base import DEFAULT_VERBOSE, MAX_FUTURE_TIMEOUT, ImageEngine
 
 __all__ = ["DuckDuckGo"]
 
@@ -95,7 +95,7 @@ class DuckDuckGo(ImageEngine):
         limit: int,
         output_dir,
         timeout: int = 30,
-        verbose: bool = True,
+        verbose: bool = DEFAULT_VERBOSE,
         badsites=None,
         name: str = "Image",
         max_workers: int = 4,

--- a/tests/test_integrability.py
+++ b/tests/test_integrability.py
@@ -22,7 +22,7 @@ def test_bing_instantiable_with_only_required_args(tmp_path: Path) -> None:
     assert b.limit == 5
     assert b.adult == "moderate"
     assert b.timeout == 60
-    assert b.verbose is True
+    assert b.verbose is False
     assert b.filter == ""
     assert b.mkt == "en-US"
 
@@ -33,6 +33,7 @@ def test_duckduckgo_instantiable_with_only_required_args(tmp_path: Path) -> None
     assert d.query == "red panda"
     assert d.limit == 5
     assert d.timeout == 30
+    assert d.verbose is False
     assert d.safe_search == "moderate"
     assert d.region == "us-en"
 

--- a/tests/test_v3_2_0_api.py
+++ b/tests/test_v3_2_0_api.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import inspect
 import tempfile
 from pathlib import Path
 
@@ -108,6 +109,24 @@ def test_downloader_zero_arg_construction() -> None:
 def test_downloader_with_session_dir() -> None:
     dl = Downloader(cache_dir=Path(tempfile.gettempdir()) / "bbid_test_cache")
     assert dl.cache_dir is not None
+
+
+def test_embeddable_verbose_defaults_match(tmp_path: Path) -> None:
+    """Direct engine use and Downloader.search should agree on quiet defaults."""
+    assert inspect.signature(Downloader.search).parameters["verbose"].default is False
+    assert inspect.signature(ImageEngine.__init__).parameters["verbose"].default is False
+    assert inspect.signature(Bing.__init__).parameters["verbose"].default is False
+    assert inspect.signature(DuckDuckGo.__init__).parameters["verbose"].default is False
+
+    class FakeEngine(ImageEngine):
+        def run(self) -> None:
+            pass
+
+    dl = Downloader()
+    dl.register("fake", FakeEngine)
+    inst = dl.build_engine(engine_name="fake", query="x", limit=1, output_dir=tmp_path)
+
+    assert inst.verbose is False
 
 
 # --- Engine registry ---
@@ -243,8 +262,6 @@ def test_downloader_search_collects_images_via_hook(tmp_path: Path) -> None:
 
 def test_legacy_downloader_function_still_works(tmp_path: Path) -> None:
     """The module-level downloader() function is preserved (delegates to Downloader)."""
-    import inspect
-
     sig = inspect.signature(downloader)
     # query is the only required parameter
     required = [


### PR DESCRIPTION
Fixes #48.

This makes the embeddable API use the same quiet default everywhere. `ImageEngine`, `Bing`, `DuckDuckGo`, `Downloader.search`, and `Downloader.search_async` now all share `DEFAULT_VERBOSE = False`, so users do not get different logging behavior depending on whether they instantiate an engine directly or go through `Downloader`.

I left the legacy `downloader()` wrapper default alone. It still passes `verbose=True` explicitly, so the older CLI-style path keeps its existing progress logging behavior.

Checked locally:
- `python -m pytest tests/test_v3_2_0_api.py tests/test_integrability.py --basetemp .pytest_tmp`
- `python -m black --check better_bing_image_downloader/base.py better_bing_image_downloader/bing.py better_bing_image_downloader/duckduckgo.py better_bing_image_downloader/downloader.py tests/test_v3_2_0_api.py tests/test_integrability.py`
- `python -m ruff check better_bing_image_downloader/base.py better_bing_image_downloader/bing.py better_bing_image_downloader/duckduckgo.py better_bing_image_downloader/downloader.py tests/test_v3_2_0_api.py tests/test_integrability.py`
- `python -m mypy better_bing_image_downloader`
- `python -m pytest --basetemp .pytest_tmp -k "not test_result_repr_includes_manifest_path_when_set and not test_result_repr_preserves_existing_flags_ordering"`

The two deselected tests are Windows path `repr()` assertions in the manifest tests; they fail the same way independently of this verbose default change because backslashes are escaped inside `repr()`.