### PR TITLE
chore(release): portable release-notes extraction + bump publish actions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ The current version is **3.5.1**. Bump in `pyproject.toml` and
 4. Tag: `git tag -a v3.X.Y -m "v3.X.Y: <one-line summary>"`.
 5. Push: `git push origin main --follow-tags`.
 6. Create a GitHub release with notes from `CHANGELOG.md` (use
-   `gh release create v3.X.Y --notes-file <(sed -n '/^## \[3.X.Y\]/,/^## /p' CHANGELOG.md | head -n -2)`).
+   `gh release create v3.X.Y --notes-file <(awk '/^## \[3.X.Y\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)`).
 7. The `python-publish.yml` workflow will publish to PyPI.
 8. Verify on https://pypi.org/project/better-bing-image-downloader/.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ Maintainers cut releases as follows:
 5. Push the branch and the tag:
    `git push origin main --follow-tags`.
 6. Create a GitHub release with notes from `CHANGELOG.md`. Use
-   `gh release create v3.X.Y --notes-file <(awk '/^## \[3.X.Y\]/{flag=1} /^## \[3.X.Y-1\]/{flag=0} flag' CHANGELOG.md)`.
+   `gh release create v3.X.Y --notes-file <(awk '/^## \[3.X.Y\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)`.
 7. The `python-publish.yml` workflow will build and upload to PyPI
    automatically. Verify on
    <https://pypi.org/project/better-bing-image-downloader/>.


### PR DESCRIPTION
Two small maintenance fixes called out during the v3.6.0 release:

## 1. Portable release-notes extraction (`AGENTS.md` + `CONTRIBUTING.md`)

The release-process commands in both docs used `sed ... | head -n -2` to trim the next-version heading off the extracted CHANGELOG section. `head -n -2` is **GNU-only**; on macOS BSD `head` it errors with `illegal line count -- -2`, which silently produced an empty notes file when cutting v3.6.0.

Replaced with a portable `awk` that prints everything between the target `## [vX.Y.Z]` heading and the next `## [` heading:

```bash
gh release create v3.X.Y --notes-file <(awk '/^## \[3.X.Y\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
```

Bonus: the new pattern doesn't require typing the previous version, so future contributors don't have to look it up. `CONTRIBUTING.md` had a different working `awk` that *did* require the previous version — harmonised to the same pattern for consistency.

Verified the new command extracts the [3.6.0] section correctly against the current CHANGELOG.md.

## 2. Bump publish workflow actions (`.github/workflows/python-publish.yml`)

Pinned `actions/checkout@v3` and `actions/setup-python@v3`, which target Node 20. GitHub is deprecating Node 20 on Actions runners and emits an annotation per build (saw it on the v3.6.0 publish run: `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24...`). Bumped to:

- `actions/checkout@v4`
- `actions/setup-python@v5`

`pypa/gh-action-pypi-publish` stays SHA-pinned to the same commit (`27b31702...`); the deprecation was on the v3 checkout/setup-python actions, not this one.

## Verification

- `pytest` → 166 passed, 2 skipped
- `ruff check .` → all checks passed
- YAML validated with `yaml.safe_load`
- New awk pattern tested against the current CHANGELOG — extracts the [3.6.0] section starting at `### Added` (excludes the version heading) and stops at `## [3.5.1]`.