### PR TITLE
docs: document commit-signing requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,25 @@ line stays under 72 characters; the body, if any, is wrapped at 72.
    git push origin feat/my-feature
    gh pr create --fill
    ```
+### Commit signing
+
+This repository enforces GPG or SSH-signed commits on the `main` branch.
+
+**Set up GPG signing locally:**
+
+```bash
+# Generate a GPG key (choose RSA 4096)
+gpg --full-generate-key
+
+# Find your key ID
+gpg --list-secret-keys --keyid-format=long
+
+# Tell Git to use it
+git config --global user.signingkey <YOUR_KEY_ID>
+git config --global commit.gpgsign true
+
+# Export your public key and add it to GitHub → Settings → SSH and GPG keys
+gpg --armor --export <YOUR_KEY_ID>
 
 5.1. **Sign your commits.** This repository's `main` branch requires
    GPG- or SSH-signed commits (`required_signatures: true`). Before

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,24 @@ git config --global commit.gpgsign true
 
 # Export your public key and add it to GitHub → Settings → SSH and GPG keys
 gpg --armor --export <YOUR_KEY_ID>
+```
+
+**Set up SSH signing locally (modern alternative):**
+
+```bash
+# Use an existing SSH key, or generate one
+ssh-keygen -t ed25519 -C "your_email@example.com"
+
+# Tell Git to use SSH signing
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+
+# Sign all commits automatically
+git config --global commit.gpgsign true
+
+# Upload ~/.ssh/id_ed25519.pub to GitHub → Settings → SSH and GPG keys
+# (GitHub auto-detects whether a key is used for auth or signing)
+```
 
 5.1. **Sign your commits.** This repository's `main` branch requires
    GPG- or SSH-signed commits (`required_signatures: true`). Before


### PR DESCRIPTION
Closes #39

Added a "Commit signing" subsection to the Pull request process section
explaining how to set up GPG signing locally and register the key on GitHub.