### PR TITLE
fix(manifest): unique per-search index for error/skip records (closes #38, #51, #27, #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Manifest writer state (writer, engine/query metadata, record
+  counter) is now invocation-local to each `Downloader.search()`
+  call instead of shared instance state, so nested or concurrent
+  searches on the same `Downloader` no longer clobber each other's
+  manifests. This is internal-only; the public API is unchanged.
 - Populated the previously-empty `docs/index.md` so the `docs/`
   directory is no longer a confusing empty page. It now documents
   that `docs/` holds internal design specs and points to the
@@ -32,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   export. Prevents the v3.5.0→v3.5.1 re-export bug class.
 - Test coverage for the per-search manifest `index` counter, including
   consecutive-error and mixed success/error/skip sequences.
+- Regression tests proving manifest state is invocation-local: a
+  nested `search()` fired from an `on_image` hook, and two threads
+  running `search()` concurrently on the same `Downloader`, each
+  keep independent writers, metadata, and 1-based counters.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Manifest records no longer collide on their `index` field when two
+  consecutive non-download records (errors, or `min_dimension`
+  skips) occur. The manifest `index` is now a strictly-increasing
+  per-search counter that counts every record (success, error, or
+  skip), matching the documented "1-based and counts every record"
+  schema. Previously, consecutive error/skip records shared the same
+  `index`, producing duplicate primary keys for downstream tooling.
+
+### Changed
+
+- Populated the previously-empty `docs/index.md` so the `docs/`
+  directory is no longer a confusing empty page. It now documents
+  that `docs/` holds internal design specs and points to the
+  `README.md` and `CONTRIBUTING.md` for user-facing documentation.
+
+### Added
+
+- Regression test (`tests/test_public_api.py`) asserting every name
+  in `better_bing_image_downloader.__all__` is importable from the
+  top-level package and resolves to the same object as its submodule
+  export. Prevents the v3.5.0→v3.5.1 re-export bug class.
+- Test coverage for the per-search manifest `index` counter, including
+  consecutive-error and mixed success/error/skip sequences.
+
+### Tests
+
+- Fixed two `Result.__repr__` tests in
+  `tests/test_v3_5_0_manifest.py` that failed on Windows because
+  `repr()` escapes backslash path separators. Assertions now compare
+  against the escaped (`repr()`) form of the path, which is
+  byte-exact on every platform.
+
 ## [3.7.1] - 2026-07-26
 
 ### Fixed

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -382,10 +382,10 @@ class Downloader:
         self._manifest_writer = manifest_writer
         self._manifest_engine_name = engine
         self._manifest_query = query
-        # Per-search record counter (v3.x.y): the manifest ``index``
-        # field is 1-based and counts *every* record (success, error,
-        # or skip). It is reset here so a re-used ``Downloader``
-        # instance starts each search's indices at 1 again.
+        # Per-search record counter: the manifest ``index`` field is
+        # 1-based and counts *every* record (success, error, or skip).
+        # It is reset here so a re-used ``Downloader`` instance starts
+        # each search's indices at 1 again.
         self._manifest_index = 0
 
         engine_kwargs: dict[str, object] = {}

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -382,6 +382,11 @@ class Downloader:
         self._manifest_writer = manifest_writer
         self._manifest_engine_name = engine
         self._manifest_query = query
+        # Per-search record counter (v3.x.y): the manifest ``index``
+        # field is 1-based and counts *every* record (success, error,
+        # or skip). It is reset here so a re-used ``Downloader``
+        # instance starts each search's indices at 1 again.
+        self._manifest_index = 0
 
         engine_kwargs: dict[str, object] = {}
         if engine == "bing":
@@ -686,15 +691,14 @@ class Downloader:
         if self._manifest_writer is None:
             return
         # ``index`` is 1-based and counts every record (success or
-        # failure). The engine's ``download_count`` is incremented
-        # inside ``download_image`` *after* ``save_image`` returns,
-        # so at the point we append to the manifest, the success
-        # path's count reflects this image and the failure path's
-        # count does not (the engine did not advance). We add 1 in
-        # the success path to make the index 1-based; the failure
-        # path's count is already the right 0-based position, but
-        # we also add 1 for consistency.
-        index = engine_obj.download_count + 1
+        # failure). We keep a per-search counter on the ``Downloader``
+        # instance (reset at the top of :meth:`search`) instead of
+        # deriving the index from the engine's internal
+        # ``download_count``: the engine only advances that counter on
+        # a successful save, so two consecutive error/skip records
+        # would otherwise share the same ``index`` value.
+        self._manifest_index += 1
+        index = self._manifest_index
         # Resolve file path relative to output_dir.
         file_rel: str | None = None
         if file_path is not None:

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -209,13 +209,11 @@ class Downloader:
         self._registry: dict[str, type[ImageEngine]] = dict(self._DEFAULT_REGISTRY)
         self._registry_lock = threading.Lock()
 
-        # --- Manifest writer (v3.5.0+). Set by ``search()``; ``None``
-        # means no manifest is being written. The success/error hooks
-        # inside ``search()`` read this attribute to decide whether to
-        # append records.
-        self._manifest_writer: ManifestWriter | None = None
-        self._manifest_engine_name: str | None = None
-        self._manifest_query: str | None = None
+        # Manifest state (v3.5.0+) is deliberately NOT kept on the
+        # instance: each ``search()`` call builds its own invocation-
+        # local :class:`_ManifestContext` so nested or concurrent
+        # searches on the same ``Downloader`` never clobber each
+        # other's writer, metadata, or record counter.
 
     # --- Engine registry ---
 
@@ -363,9 +361,11 @@ class Downloader:
         # Constructed here so it is open and ready to receive
         # records from the very first image attempt. Wrapped in
         # try/finally below to guarantee ``close()`` is called
-        # even on exception. ``self._manifest_writer`` is also
-        # set on the instance so the success/error hooks inside
-        # ``_run_engine`` can append records to it.
+        # even on exception. The writer and its metadata live in an
+        # invocation-local :class:`_ManifestContext` (not on ``self``)
+        # so nested ``search()`` calls from hooks, or concurrent
+        # searches on the same ``Downloader``, each get their own
+        # writer and 1-based record counter.
         manifest_writer: ManifestWriter | None = None
         manifest_abs_path: str | None = None
         if manifest:
@@ -378,15 +378,13 @@ class Downloader:
                 flush_every=manifest_flush_every,
             )
             manifest_abs_path = str(resolved_manifest_path.resolve())
-        # Expose to the success/error hooks below.
-        self._manifest_writer = manifest_writer
-        self._manifest_engine_name = engine
-        self._manifest_query = query
-        # Per-search record counter: the manifest ``index`` field is
-        # 1-based and counts *every* record (success, error, or skip).
-        # It is reset here so a re-used ``Downloader`` instance starts
-        # each search's indices at 1 again.
-        self._manifest_index = 0
+        # Invocation-local manifest context, closed over by the
+        # success/error/skip hooks below.
+        manifest_ctx: _ManifestContext | None = (
+            _ManifestContext(manifest_writer, engine, query)
+            if manifest_writer is not None
+            else None
+        )
 
         engine_kwargs: dict[str, object] = {}
         if engine == "bing":
@@ -500,8 +498,9 @@ class Downloader:
                 # into Result.errors or fire on_error. It's recorded
                 # as a manifest "skip" and counted in Result.skipped.
                 min_dimension_skips += 1
-                if self._manifest_writer is not None:
-                    self._append_manifest_record(
+                if manifest_ctx is not None:
+                    _append_manifest_record(
+                        manifest_ctx,
                         status="skipped",
                         url=link,
                         file_path=None,
@@ -520,8 +519,9 @@ class Downloader:
                     except Exception:
                         logging.exception("on_error hook raised; continuing")
                 # Manifest append (v3.5.0+): record the typed failure.
-                if self._manifest_writer is not None:
-                    self._append_manifest_record(
+                if manifest_ctx is not None:
+                    _append_manifest_record(
+                        manifest_ctx,
                         status="error",
                         url=link,
                         file_path=None,
@@ -540,8 +540,9 @@ class Downloader:
                     except Exception:
                         logging.exception("on_error hook raised; continuing")
                 # Manifest append (v3.5.0+): record the unhandled failure.
-                if self._manifest_writer is not None:
-                    self._append_manifest_record(
+                if manifest_ctx is not None:
+                    _append_manifest_record(
+                        manifest_ctx,
                         status="error",
                         url=link,
                         file_path=None,
@@ -590,8 +591,9 @@ class Downloader:
                 except Exception:
                     logging.exception("on_progress hook raised; continuing")
             # Manifest append (v3.5.0+): one record per successful save.
-            if self._manifest_writer is not None:
-                self._append_manifest_record(
+            if manifest_ctx is not None:
+                _append_manifest_record(
+                    manifest_ctx,
                     status="ok",
                     url=link,
                     file_path=fp,
@@ -666,60 +668,6 @@ class Downloader:
                 logging.exception("on_engine_done hook raised; continuing")
 
         return result
-
-    def _append_manifest_record(
-        self,
-        status: str,
-        url: str,
-        file_path: Path | None,
-        md5: str | None,
-        error: BaseException | None,
-        engine_obj: ImageEngine,
-    ) -> None:
-        """Build a manifest record dict and append it to the writer.
-
-        Called from the success and error paths inside :meth:`search`
-        when ``manifest=True`` was passed. The record is filtered to
-        the writer's configured fields automatically.
-
-        ``file_path`` is stored relative to ``output_dir`` (i.e. as
-        ``"<query>/Image_1.jpg"``) so the manifest is portable
-        across machines. If the relative-to conversion fails (e.g.
-        the engine wrote outside ``output_dir``), the basename is
-        used as a fallback.
-        """
-        if self._manifest_writer is None:
-            return
-        # ``index`` is 1-based and counts every record (success or
-        # failure). We keep a per-search counter on the ``Downloader``
-        # instance (reset at the top of :meth:`search`) instead of
-        # deriving the index from the engine's internal
-        # ``download_count``: the engine only advances that counter on
-        # a successful save, so two consecutive error/skip records
-        # would otherwise share the same ``index`` value.
-        self._manifest_index += 1
-        index = self._manifest_index
-        # Resolve file path relative to output_dir.
-        file_rel: str | None = None
-        if file_path is not None:
-            try:
-                file_rel = str(file_path.resolve().relative_to(Path.cwd()))
-            except ValueError:
-                file_rel = file_path.name
-        self._manifest_writer.append(
-            {
-                "index": index,
-                "status": status,
-                "url": url,
-                "file": file_rel,
-                "md5": md5,
-                "error": type(error).__name__ if error is not None else None,
-                "engine": self._manifest_engine_name,
-                "query": self._manifest_query,
-                "source_page": getattr(engine_obj, "last_page_url", None),
-                "downloaded_at": _utcnow_iso(),
-            }
-        )
 
     async def search_async(
         self,
@@ -808,6 +756,81 @@ def _utcnow_iso() -> str:
     ``downloaded_at`` field. Format: ``YYYY-MM-DDTHH:MM:SSZ``.
     """
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class _ManifestContext:
+    """Invocation-local manifest state for a single ``search()`` call.
+
+    Holds the writer, the engine/query provenance metadata, and the
+    1-based record counter. A fresh instance is created at the top of
+    every ``search()`` call and closed over by the success/error/skip
+    hooks — it is deliberately NOT stored on the ``Downloader``
+    instance, so a nested ``search()`` fired from an ``on_image``
+    hook, or two threads running ``search()`` concurrently on the
+    same ``Downloader``, each get independent writers and counters.
+    """
+
+    __slots__ = ("writer", "engine_name", "query", "index")
+
+    def __init__(self, writer: ManifestWriter, engine_name: str, query: str) -> None:
+        self.writer = writer
+        self.engine_name = engine_name
+        self.query = query
+        # 1-based record counter, incremented by
+        # ``_append_manifest_record`` on every record.
+        self.index = 0
+
+
+def _append_manifest_record(
+    manifest_ctx: _ManifestContext,
+    status: str,
+    url: str,
+    file_path: Path | None,
+    md5: str | None,
+    error: BaseException | None,
+    engine_obj: ImageEngine,
+) -> None:
+    """Build a manifest record dict and append it to the context's writer.
+
+    Called from the success and error paths inside ``Downloader.search``
+    when ``manifest=True`` was passed. The record is filtered to
+    the writer's configured fields automatically.
+
+    ``file_path`` is stored relative to ``output_dir`` (i.e. as
+    ``"<query>/Image_1.jpg"``) so the manifest is portable
+    across machines. If the relative-to conversion fails (e.g.
+    the engine wrote outside ``output_dir``), the basename is
+    used as a fallback.
+    """
+    # ``index`` is 1-based and counts every record (success or
+    # failure). We keep a per-search counter on the invocation-local
+    # context instead of deriving the index from the engine's internal
+    # ``download_count``: the engine only advances that counter on
+    # a successful save, so two consecutive error/skip records
+    # would otherwise share the same ``index`` value.
+    manifest_ctx.index += 1
+    index = manifest_ctx.index
+    # Resolve file path relative to output_dir.
+    file_rel: str | None = None
+    if file_path is not None:
+        try:
+            file_rel = str(file_path.resolve().relative_to(Path.cwd()))
+        except ValueError:
+            file_rel = file_path.name
+    manifest_ctx.writer.append(
+        {
+            "index": index,
+            "status": status,
+            "url": url,
+            "file": file_rel,
+            "md5": md5,
+            "error": type(error).__name__ if error is not None else None,
+            "engine": manifest_ctx.engine_name,
+            "query": manifest_ctx.query,
+            "source_page": getattr(engine_obj, "last_page_url", None),
+            "downloaded_at": _utcnow_iso(),
+        }
+    )
 
 
 def _compute_eta(state: dict[str, float | int], done: int, total: int) -> float | None:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# Better Bing Image Downloader — internal docs
+
+This `docs/` directory holds **internal design documents and specs**
+only. It is not a published documentation site.
+
+For user-facing documentation, see the top-level [`README.md`](../README.md)
+and the [`CONTRIBUTING.md`](../CONTRIBUTING.md) contributor guide.
+
+## Design specs
+
+- [`superpowers/specs/2026-06-13-v3-5-0-manifest-design.md`](superpowers/specs/2026-06-13-v3-5-0-manifest-design.md)
+  — Design for the v3.5.0 JSONL manifest export
+  (`ManifestWriter`, `Downloader.search(manifest=True)`).
+
+New design specs live under `docs/superpowers/specs/`, named
+`YYYY-MM-DD-<slug>-design.md`.
+
+## Repository
+
+- Source: <https://github.com/KTS-o7/better_bing_image_downloader>

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,61 @@
+"""Regression tests for the top-level public API surface.
+
+Guards against the v3.5.0 -> v3.5.1 bug class, where a new public
+symbol (``ManifestWriter``) was added to a submodule's exports and to
+``downloader.py:__all__`` but not to the package's top-level
+``__init__.py``, making ``from better_bing_image_downloader import
+ManifestWriter`` fail at release time.
+
+These tests fail loudly if any future name added to ``__all__`` is
+missing from ``__init__.py``, or if the top-level export resolves to a
+*different* object than the submodule one.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import better_bing_image_downloader as pkg
+
+# Every symbol in the package ``__all__`` and the submodule it is
+# defined in. Kept in sync with ``better_bing_image_downloader/__init__.py``.
+_SUBMODULE_OF = {
+    "BelowMinDimension": "base",
+    "Bing": "bing",
+    "CancelToken": "downloader",
+    "DEFAULT_MANIFEST_FIELDS": "manifest",
+    "Downloader": "downloader",
+    "DuplicateImageError": "base",
+    "DuckDuckGo": "duckduckgo",
+    "ImageEngine": "base",
+    "ImageResult": "results",
+    "ImageSaveError": "base",
+    "InvalidImageError": "base",
+    "ManifestFieldError": "manifest",
+    "ManifestWriter": "manifest",
+    "NetworkError": "base",
+    "Result": "results",
+    "WriteError": "base",
+    "downloader": "download",
+}
+
+
+@pytest.mark.parametrize("name", sorted(set(pkg.__all__)))
+def test_every_all_name_is_importable_from_top_level(name: str) -> None:
+    """``from better_bing_image_downloader import <name>`` must work."""
+    namespace: dict = {}
+    exec(f"from better_bing_image_downloader import {name}", namespace)  # noqa: S102
+    assert namespace[name] is getattr(pkg, name)
+
+
+@pytest.mark.parametrize("name", sorted(set(pkg.__all__)))
+def test_top_level_export_is_same_object_as_submodule(name: str) -> None:
+    """Top-level re-exports must resolve to the submodule's object.
+
+    Catches the "imported into __init__ but as a different object"
+    variant of the re-export bug.
+    """
+    submodule = importlib.import_module(f"better_bing_image_downloader.{_SUBMODULE_OF[name]}")
+    assert getattr(pkg, name) is getattr(submodule, name)

--- a/tests/test_v3_5_0_manifest.py
+++ b/tests/test_v3_5_0_manifest.py
@@ -622,6 +622,117 @@ def test_search_manifest_writer_closed_on_exception(tmp_path: Path) -> None:
     assert all(r["status"] == "ok" for r in records)
 
 
+# --- Group B2: invocation-local manifest state (nested/concurrent searches) ---
+
+
+def test_search_manifest_nested_search_from_on_image_hook(tmp_path: Path) -> None:
+    """An on_image hook that calls search() again must not clobber the outer manifest.
+
+    Both searches run on the SAME Downloader instance. The inner
+    search gets its own writer and 1-based counter; the outer
+    search's indices must still be [1, 2] with its own metadata.
+    """
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_two_ok_stub())
+
+    def fake_http_get(self, url, headers=None):
+        return b"\xff\xd8\xff\xe0" + url.encode("utf-8")
+
+    outer_dir = tmp_path / "outer"
+    inner_dir = tmp_path / "inner"
+    inner_results: list = []
+
+    nesting = {"active": False}
+
+    def on_image_nested(ir) -> None:
+        # Fire a nested search from inside the outer search's hook.
+        # The guard prevents infinite recursion: the hook is
+        # instance-wide, so the inner search's own on_image events
+        # would re-trigger it otherwise.
+        if nesting["active"] or inner_results:
+            return
+        nesting["active"] = True
+        try:
+            inner_results.append(
+                dl.search("dog", limit=2, engine="stub", output_dir=inner_dir, manifest=True)
+            )
+        finally:
+            nesting["active"] = False
+
+    dl.on_image = on_image_nested
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        outer = dl.search("cat", limit=2, engine="stub", output_dir=outer_dir, manifest=True)
+
+    assert len(inner_results) == 1
+    inner = inner_results[0]
+
+    outer_records = [
+        json.loads(line)
+        for line in Path(outer.manifest_path).read_text(encoding="utf-8").splitlines()
+    ]
+    inner_records = [
+        json.loads(line)
+        for line in Path(inner.manifest_path).read_text(encoding="utf-8").splitlines()
+    ]
+
+    # Outer search: indices still strictly 1-based despite the nested
+    # search running in the middle of it.
+    assert [r["index"] for r in outer_records] == [1, 2]
+    assert all(r["query"] == "cat" for r in outer_records)
+    # Inner search: its own writer and counter, starting at 1.
+    assert [r["index"] for r in inner_records] == [1, 2]
+    assert all(r["query"] == "dog" for r in inner_records)
+
+
+def test_search_manifest_concurrent_searches_same_downloader(tmp_path: Path) -> None:
+    """Two threads running search() on the same Downloader keep separate manifests.
+
+    Each thread writes to its own output dir; indices must be
+    strictly increasing starting at 1 in each manifest, and no
+    records may leak between the two (each manifest contains only
+    its own query/engine records).
+    """
+    import threading
+
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+    dl.register("stub", _make_two_ok_stub())
+
+    def fake_http_get(self, url, headers=None):
+        return b"\xff\xd8\xff\xe0" + url.encode("utf-8")
+
+    results: dict[str, object] = {}
+
+    def run_search(query: str, out_dir: Path) -> None:
+        results[query] = dl.search(query, limit=2, engine="stub", output_dir=out_dir, manifest=True)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        threads = [
+            threading.Thread(target=run_search, args=("cat", tmp_path / "a")),
+            threading.Thread(target=run_search, args=("dog", tmp_path / "b")),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert set(results.keys()) == {"cat", "dog"}
+    for query in ("cat", "dog"):
+        result = results[query]
+        records = [
+            json.loads(line)
+            for line in Path(result.manifest_path).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [r["index"] for r in records] == [1, 2]
+        # No cross-contamination between the two manifests.
+        assert all(r["query"] == query for r in records)
+        assert all(r["engine"] == "stub" for r in records)
+
+
 # --- Group C: Result + CLI integration (4 tests) ---
 
 

--- a/tests/test_v3_5_0_manifest.py
+++ b/tests/test_v3_5_0_manifest.py
@@ -491,6 +491,84 @@ def test_search_manifest_records_index_is_one_based_and_sequential(tmp_path: Pat
     assert indices == [1, 2, 3]
 
 
+def _make_png(width: int, height: int) -> bytes:
+    """Header-only PNG for dimension filtering (no real pixel data)."""
+    import struct
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    chunk = struct.pack(">I", len(ihdr_data)) + b"IHDR" + ihdr_data + b"\x00\x00\x00\x00"
+    return sig + chunk
+
+
+def test_search_manifest_consecutive_errors_get_unique_indices(tmp_path: Path) -> None:
+    """Two consecutive failures with no success between them must not share an index (#38)."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+
+    class TwoConsecutiveErrorsStub(ImageEngine):
+        def run(self) -> None:
+            self.download_image("https://x.test/a.png", 1)
+            self.download_image("https://x.test/b.png", 2)
+
+    dl.register("bad", TwoConsecutiveErrorsStub)
+
+    def failing_http_get(self, url, headers=None):
+        raise OSError("simulated network failure")
+
+    with patch.object(_base.ImageEngine, "_http_get", failing_http_get):
+        result = dl.search("q", limit=2, engine="bad", output_dir=tmp_path, manifest=True)
+
+    lines = Path(result.manifest_path).read_text(encoding="utf-8").splitlines()
+    indices = [json.loads(line)["index"] for line in lines]
+    assert indices == [1, 2]
+    assert len(set(indices)) == len(indices)
+
+
+def test_search_manifest_mixed_records_indices_strictly_increasing(tmp_path: Path) -> None:
+    """error + ok + min_dimension-skip records produce unique, sequential indices (#38)."""
+    from better_bing_image_downloader import base as _base
+
+    dl = Downloader()
+
+    class MixedStub(ImageEngine):
+        def run(self) -> None:
+            # 1: error (broken bytes)
+            self.download_image("https://x.test/broken.jpg", 1)
+            # 2: ok (large image)
+            self.download_image("https://x.test/large.png", 2)
+            # 3: min_dimension skip (tiny image)
+            self.download_image("https://x.test/tiny.png", 3)
+
+    dl.register("mixed", MixedStub)
+
+    def fake_http_get(self, url, headers=None):
+        if "broken" in url:
+            return b"not an image"
+        if "tiny" in url:
+            return _make_png(10, 10)
+        return _make_png(800, 600)
+
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        result = dl.search(
+            "q",
+            limit=3,
+            engine="mixed",
+            output_dir=tmp_path,
+            manifest=True,
+            min_dimension=200,
+        )
+
+    lines = Path(result.manifest_path).read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in lines]
+    statuses = [r["status"] for r in records]
+    indices = [r["index"] for r in records]
+    assert statuses == ["error", "ok", "skipped"]
+    assert indices == [1, 2, 3]
+    assert indices == sorted(set(indices))
+
+
 def test_search_manifest_records_have_utc_timestamp(tmp_path: Path) -> None:
     """downloaded_at is an ISO 8601 UTC string with a trailing 'Z'."""
     from better_bing_image_downloader import base as _base
@@ -742,7 +820,9 @@ def test_result_repr_includes_manifest_path_when_set(tmp_path: Path) -> None:
     text = repr(r)
     assert "manifest.jsonl" in text
     assert "manifest_path" in text
-    assert str(tmp_path / "manifest.jsonl") in text
+    # ``repr()`` escapes Windows backslashes, so compare against the
+    # escaped form on every platform (POSIX paths match unchanged).
+    assert repr(str(tmp_path / "manifest.jsonl")) in text
 
 
 def test_result_repr_includes_no_manifest_sentinel_when_none(tmp_path: Path) -> None:
@@ -773,6 +853,8 @@ def test_result_repr_preserves_existing_flags_ordering(tmp_path: Path) -> None:
     )
     text = repr(r)
     # The existing flags= list and trailing manifest_path should both
-    # still be present, in the documented order.
+    # still be present, in the documented order. Compare against the
+    # ``repr()``-escaped path so the assertion holds on Windows (where
+    # ``repr()`` turns backslashes into ``\\``).
     assert "flags=['no_results_found', 'cancelled']" in text
-    assert text.endswith("manifest_path='" + str(tmp_path / "m.jsonl") + "')")
+    assert text.endswith("manifest_path=" + repr(str(tmp_path / "m.jsonl")) + ")")


### PR DESCRIPTION
﻿Closes #38, #51, #27, #47

## What & why

This PR fixes a data-integrity bug in the JSONL manifest, two Windows-only test failures, and adds two regression tests for the public API surface. Details per issue:

### #38 - Manifest index collides for consecutive non-download records
`_append_manifest_record` derived the index from `engine.download_count + 1`. The engine counter only advances on a successful save, so consecutive error records (or min_dimension skips) shared the same index. Downstream tooling that joins on index silently gets duplicate primary keys, and the docs (1-based, counts every record) disagreed with the implementation.

Fix: a per-search counter (self._manifest_index) reset at the top of search(), incremented once per _append_manifest_record call. Indices are now strictly increasing across all record types, and each search starts at 1 again (re-using a Downloader no longer continues a stale sequence).

### #51 - Two Result.__repr__ tests fail on Windows
str(tmp_path / "m.jsonl") contains single backslashes, but repr() escapes them as double backslashes, so the exact-string assertions never matched on Windows. The issue's option 2 (compare against the repr()-escaped form) is used, which is byte-exact on every platform.

### #27 - Regression test for top-level imports
Added tests/test_public_api.py:
- every name in better_bing_image_downloader.__all__ is importable via from better_bing_image_downloader import <name>
- each top-level export is the same object as its submodule export

This would have caught the v3.5.0 to v3.5.1 ManifestWriter re-export bug.

### #47 - Empty docs/index.md
Populated it: documents that docs/ holds internal design specs only, links the README.md/CONTRIBUTING.md, and indexes the v3.5.0 manifest spec.

## Validation

- pytest: 200 passed, 4 skipped (network tests)
- ruff check .: clean
- mypy: no issues
- black --check: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed manifest record numbering so successful, failed, and skipped downloads receive unique sequential indexes for each search.
  * Ensured nested and concurrent searches maintain independent manifest data.
  * Improved cross-platform handling of result representations, including Windows paths.

* **Documentation**
  * Added documentation navigation, repository links, and the v3.5.0 manifest design reference.

* **Tests**
  * Added regression coverage for manifest indexing, concurrent searches, and public package exports.
  * Expanded testing for mixed download outcomes and image-dimension filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->