### PR TITLE
chore: v3.8.1 polish — deprecation warnings, thread-safety docs, CLI test, README refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `crawler`, `helperdownload`, and `utils` now emit a
+  `DeprecationWarning` at import time, matching the existing runtime
+  warning in `multidownloader.main()`. All four modules are still
+  scheduled for removal in v4.0.0.
+- CLI smoke tests for `bbid --version` (`tests/test_cli.py`), covering
+  both in-process invocation and a real subprocess.
+- A "Thread safety" section in the `Downloader` docstring documenting
+  the concurrency contract: instances are safe to share across threads
+  only with `manifest=False`; `CancelToken` is thread-safe.
+
+### Changed
+
+- Refreshed the README Features list, which still described the v3.0.x
+  surface: it now covers the embeddable `Downloader` API, JSONL
+  manifest export, `min_dimension`, proxy support, and `CancelToken`,
+  and no longer advertises the legacy `_manifest.json` as the download
+  manifest. Quick Start now leads with the `Downloader` API, and the
+  legacy `_manifest.json` section is explicitly labelled as such.
+
 ## [3.8.0] - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,16 +10,19 @@ A fast, reliable Python library and CLI tool for bulk downloading images from Bi
 
 ## Features
 
+- **Embeddable `Downloader` API** — search programmatically with `Result` / `ImageResult` value objects, lifecycle hooks (`on_image`, `on_error`, `on_progress`, `on_engine_start`, `on_engine_done`), and `search_async` for asyncio code
 - **Two search engines, one API** — Bing (default) or DuckDuckGo, switched via a single `engine=` parameter
+- **JSONL manifest export** (`manifest=True`) — one record per download attempt, crash-safe, downstream-auditable
+- **`min_dimension` filter** — skip images smaller than N pixels on either side, useful for ML training data prep
+- **HTTP/HTTPS proxy support** — route all traffic through a proxy with a single `proxy=` parameter
+- **Cancel mid-run** via `CancelToken` — abort a `search()` cleanly without leaving partial state
 - **No browser required** — both engines use plain HTTP/JSON (no Selenium, no headless Chrome)
 - **Parallel downloading** with configurable worker threads (atomic writes, no partial files)
 - **Resume support** — re-running skips already-downloaded files and fills the gap
-- **Download manifest** — `_manifest.json` written per run mapping filenames to source URLs
 - **Image deduplication** — MD5 hash check prevents saving the same image twice from different URLs
 - **Image type validation** — `filetype` library rejects non-image responses
 - **Filtering** by image type (photo, clipart, line drawing, animated gif, transparent) on Bing
-- **Adult content filter** control
-- **Bad sites exclusion** list
+- **Adult content filter** control, **bad sites** exclusion list
 - **`bbid` CLI command** installed automatically with the package
 - **Exponential backoff** on network errors with per-page retry
 - Requires Python 3.8+
@@ -65,16 +68,19 @@ pip install -e ".[dev]"
 ## Quick Start
 
 ```python
-from better_bing_image_downloader import downloader
+from better_bing_image_downloader import Downloader
 
 # Bing (default)
-downloader("golden retriever", limit=50)
+result = Downloader().search("golden retriever", limit=50)
 # → downloads to ./dataset/golden retriever/
-# → writes ./dataset/golden retriever/_manifest.json
+print(result.count, "images saved to", result.output_dir)
 
 # DuckDuckGo
-downloader("golden retriever", limit=50, engine="duckduckgo")
+result = Downloader().search("golden retriever", limit=50, engine="duckduckgo")
 ```
+
+The legacy `downloader()` function (`downloader("golden retriever", limit=50)`)
+still works and is kept for backwards compatibility.
 
 ```bash
 # Bing (default)
@@ -412,9 +418,11 @@ downloader("cats", limit=150, output_dir="dataset")
 downloader("cats", limit=150, output_dir="dataset", engine="duckduckgo")
 ```
 
-### Download manifest
+### Download manifest (legacy)
 
-After every run, `_manifest.json` is written to the output directory:
+The legacy `downloader()` function also writes a `_manifest.json` file to the
+output directory after every run — a v3.1.x format kept for backwards
+compatibility:
 
 ```json
 {
@@ -423,7 +431,9 @@ After every run, `_manifest.json` is written to the output directory:
 }
 ```
 
-Successive runs merge into the existing manifest.
+Successive runs merge into the existing manifest. Prefer the JSONL
+`manifest.jsonl` export (see above) for new tooling — it records one
+entry per download attempt, including errors and skips.
 
 ### Backward compatibility
 

--- a/better_bing_image_downloader/crawler.py
+++ b/better_bing_image_downloader/crawler.py
@@ -21,6 +21,7 @@ import logging
 import re
 import shutil
 import time
+import warnings
 from urllib.parse import quote
 
 import requests
@@ -29,6 +30,14 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+
+warnings.warn(
+    "better_bing_image_downloader.crawler is deprecated and will be removed "
+    "in v4.0.0. Use better_bing_image_downloader.Downloader with "
+    'engine="bing" or engine="duckduckgo" instead.',
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # Default headers for HTTP requests
 g_headers = {

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -163,6 +163,23 @@ class Downloader:
         requests behave exactly as before and honour the standard
         ``HTTP_PROXY``/``HTTPS_PROXY`` environment variables.
 
+    Thread safety
+    -------------
+    A ``Downloader`` instance may be shared across threads **only when
+    every ``search()`` call uses ``manifest=False``** (the default):
+    after construction, ``search()`` is read-only with respect to the
+    engine registry and the cookie jar is only used through per-request
+    opener state.
+
+    When ``manifest=True`` the instance is **not safe to share across
+    threads** — the underlying ``ManifestWriter`` is single-threaded,
+    and concurrent ``search(manifest=True)`` calls on the same instance
+    can interleave or corrupt ``manifest.jsonl`` records. Use one
+    ``Downloader`` per thread in that case.
+
+    ``CancelToken`` is thread-safe and can be shared freely: call
+    ``cancel()`` from any thread to abort a running ``search()``.
+
     Examples
     --------
     Minimal one-liner:

--- a/better_bing_image_downloader/helperdownload.py
+++ b/better_bing_image_downloader/helperdownload.py
@@ -1,6 +1,11 @@
 """Download images by URL list with automatic renaming.
 
 Used by the optional Selenium-based ``multidownloader`` path.
+
+.. deprecated::
+    This module will be removed in v4.0.0 together with
+    ``multidownloader``. Use :class:`better_bing_image_downloader.Downloader`
+    instead.
 """
 
 from __future__ import annotations
@@ -11,11 +16,19 @@ import os
 import shutil
 import tempfile
 import time
+import warnings
 
 import filetype
 import requests
 
 from .base import MAX_FUTURE_TIMEOUT, VALID_IMAGE_EXTENSIONS
+
+warnings.warn(
+    "better_bing_image_downloader.helperdownload is deprecated and will be "
+    "removed in v4.0.0. Use better_bing_image_downloader.Downloader instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["VALID_IMAGE_EXTENSIONS", "download_image", "download_images"]
 

--- a/better_bing_image_downloader/utils.py
+++ b/better_bing_image_downloader/utils.py
@@ -1,6 +1,16 @@
 # author: Krishnatejaswi S
 # Email: shentharkrishnatejaswi@gmail.com
 
+import warnings
+
+warnings.warn(
+    "better_bing_image_downloader.utils is deprecated and will be removed "
+    "in v4.0.0. It is only used by the deprecated multidownloader path; "
+    "use better_bing_image_downloader.Downloader instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 def gen_valid_dir_name_for_keywords(keywords):
     keep = ["-", "_", "."]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 """CLI smoke tests for the ``bbid`` entry point."""
 
+from __future__ import annotations
+
 import subprocess
 import sys
 from importlib.metadata import PackageNotFoundError

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,54 @@
+"""CLI smoke tests for the ``bbid`` entry point."""
+
+import subprocess
+import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
+
+import pytest
+
+from better_bing_image_downloader import download
+
+
+def _installed_version() -> str | None:
+    try:
+        return pkg_version("better-bing-image-downloader")
+    except PackageNotFoundError:
+        return None
+
+
+def test_version_flag_via_argv(monkeypatch, capsys) -> None:
+    """``bbid --version`` exits 0 and prints the installed version."""
+    monkeypatch.setattr(sys, "argv", ["bbid", "--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        download.main()
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert out.startswith("bbid ")
+    installed = _installed_version()
+    if installed is not None:
+        assert installed in out
+    else:
+        # Running from source without an install: 'unknown' is expected.
+        assert "unknown" in out
+
+
+def test_version_flag_via_subprocess() -> None:
+    """The same flag works when the CLI runs as a separate process."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from better_bing_image_downloader.download import main; main()",
+            "--version",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    installed = _installed_version()
+    if installed is not None:
+        assert installed in result.stdout
+    else:
+        assert "unknown" in result.stdout

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,3 +132,25 @@ class TestMultidownloaderDeprecated:
         from better_bing_image_downloader import crawler
 
         assert "deprecated" in crawler.__doc__.lower()
+
+
+class TestDeprecatedModulesWarnOnImport:
+    """``crawler``, ``helperdownload``, and ``utils`` must emit a
+    ``DeprecationWarning`` at import time (removed in v4.0.0)."""
+
+    def _assert_warns_on_reload(self, module_name: str) -> None:
+        import importlib
+
+        module = importlib.import_module(module_name)
+        with pytest.warns(DeprecationWarning, match=module_name.rsplit(".", 1)[-1]):
+            importlib.reload(module)
+
+    def test_crawler_import_emits_deprecation_warning(self):
+        pytest.importorskip("selenium")
+        self._assert_warns_on_reload("better_bing_image_downloader.crawler")
+
+    def test_helperdownload_import_emits_deprecation_warning(self):
+        self._assert_warns_on_reload("better_bing_image_downloader.helperdownload")
+
+    def test_utils_import_emits_deprecation_warning(self):
+        self._assert_warns_on_reload("better_bing_image_downloader.utils")


### PR DESCRIPTION
Batch of four small open issues, one commit each:

- **closes #45** — `crawler.py`, `helperdownload.py`, and `utils.py` now emit a `DeprecationWarning` at import time, matching the existing warning in `multidownloader.main()`. Three new tests in `tests/test_engine.py` assert the warning fires (via `importlib.reload`); the existing docstring checks are kept.
- **closes #29** — adds a "Thread safety" section to the `Downloader` class docstring: safe to share across threads only with `manifest=False`; `ManifestWriter` is single-threaded; `CancelToken` is thread-safe. Docstring only, no enforcement (the optional runtime check in the issue was marked optional).
- **closes #33** — new `tests/test_cli.py` with two `bbid --version` smoke tests: in-process via monkeypatched `sys.argv` and a real subprocess. Both work installed or from source.
- **closes #46** — README Features list refreshed for v3.2–v3.8 (embeddable `Downloader` API, JSONL manifest, `min_dimension`, proxy support, `CancelToken`); Quick Start now leads with `Downloader().search()`; the legacy `_manifest.json` section is explicitly labelled as legacy.

Also adds CHANGELOG "Unreleased" entries for all four.

## Verification

- `pytest`: 220 passed, 2 skipped (network)
- `black --check`, `ruff check`, `mypy`: all clean
- Note: `pre-commit run --all-files` could not run — the cached mypy hook environment is corrupted locally (`git checkout v1.18.0` fails inside pre-commit's mirror). The three tools were run directly instead; CI will exercise the full pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with current API guidance, including async search, JSONL manifests, filtering, proxy support, cancellation, and legacy compatibility.
  - Documented thread-safety considerations for concurrent downloads and manifest writing.
  - Added unreleased changelog entries.

- **Deprecations**
  - Added import-time warnings for legacy modules, directing users to the current `Downloader` API ahead of their removal in v4.0.0.

- **Tests**
  - Added CLI version smoke tests and coverage confirming deprecation warnings behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->