### PR TITLE
test+docs: CLI manifest-flag smoke tests and manifest JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scheduled for removal in v4.0.0.
 - CLI smoke tests for `bbid --version` (`tests/test_cli.py`), covering
   both in-process invocation and a real subprocess.
+- CLI smoke tests for the v3.5.0 manifest flags (`--manifest`,
+  `--manifest-path`, `--manifest-fields`, `--manifest-flush-every`),
+  exercising the argparse-to-`downloader()` wiring end-to-end with the
+  network stubbed.
+- `docs/manifest.schema.json`: a JSON Schema (Draft 2020-12)
+  describing the `manifest.jsonl` record format, referenced from the
+  README and the `manifest.py` docstring.
+  `tests/test_manifest_schema.py` validates real writer output against
+  the schema so the two cannot silently drift apart. `jsonschema` was
+  added to the dev dependencies (test-only; not a runtime dep).
 - A "Thread safety" section in the `Downloader` docstring documenting
   the concurrency contract: instances are safe to share across threads
   only with `manifest=False`; `CancelToken` is thread-safe.

--- a/README.md
+++ b/README.md
@@ -351,7 +351,9 @@ Each line is a self-contained JSON object:
 Status values are `"ok"`, `"error"`, or `"skipped"`. The
 `source_page` field is the URL of the search-results page the
 image came from. Failed downloads record the typed exception
-class name in `error` (e.g. `"NetworkError"`).
+class name in `error` (e.g. `"NetworkError"`). The record format
+is described by [`docs/manifest.schema.json`](docs/manifest.schema.json)
+(JSON Schema Draft 2020-12).
 
 The manifest is line-buffered and flushed after every record by
 default, so a partial run leaves a valid (partial) file. Use

--- a/better_bing_image_downloader/manifest.py
+++ b/better_bing_image_downloader/manifest.py
@@ -19,6 +19,10 @@ Public surface:
 - :class:`ManifestWriter` — the writer
 - :class:`ManifestFieldError` — raised when an unknown field is requested
 - :data:`DEFAULT_MANIFEST_FIELDS` — the default 10-field set
+
+The on-disk record format is the public contract; it is described by
+``docs/manifest.schema.json`` (JSON Schema Draft 2020-12) in the
+repository.
 """
 
 from __future__ import annotations

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/KTS-o7/better_bing_image_downloader/main/docs/manifest.schema.json",
+  "title": "better-bing-image-downloader manifest record",
+  "description": "One line of a manifest.jsonl file written by Downloader.search(manifest=True) (v3.5.0+). This schema describes a full record written with the default 10-field set (DEFAULT_MANIFEST_FIELDS). When a custom manifest_fields list is configured, each record is a projection of this schema containing only the requested fields.",
+  "type": "object",
+  "required": [
+    "index",
+    "status",
+    "url",
+    "file",
+    "md5",
+    "error",
+    "engine",
+    "query",
+    "source_page",
+    "downloaded_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "index": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "1-based per-search counter. Counts every record (ok, error, or skipped); strictly increasing within one search."
+    },
+    "status": {
+      "enum": ["ok", "error", "skipped"],
+      "description": "'ok' = image saved; 'error' = download/validation failed; 'skipped' = filtered out (e.g. below min_dimension, v3.6.0+)."
+    },
+    "url": {
+      "type": "string",
+      "description": "Source image URL."
+    },
+    "file": {
+      "type": ["string", "null"],
+      "description": "Saved file path relative to the working directory (e.g. 'dataset/cats/Image_1.jpg'). Null when nothing was saved (error/skipped records)."
+    },
+    "md5": {
+      "type": ["string", "null"],
+      "description": "MD5 hex digest of the saved file. Null when nothing was saved."
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Exception class name on failure or skip (e.g. 'NetworkError', 'BelowMinDimension'). Null on success."
+    },
+    "engine": {
+      "type": "string",
+      "description": "Engine name, e.g. 'bing' or 'duckduckgo'."
+    },
+    "query": {
+      "type": "string",
+      "description": "The search query that produced this record."
+    },
+    "source_page": {
+      "type": ["string", "null"],
+      "description": "URL of the search-result page the image link was found on."
+    },
+    "downloaded_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp, e.g. '2026-06-13T10:20:30Z'."
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "ruff>=0.6.0",
     "mypy>=1.10",
     "pre-commit>=3.5",
+    "jsonschema>=4.0",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,6 @@ black>=24.0
 ruff>=0.6.0
 mypy>=1.10
 pre-commit>=3.5
+
+# Schema validation (tests/test_manifest_schema.py)
+jsonschema>=4.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+import urllib.request
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 
@@ -54,3 +56,141 @@ def test_version_flag_via_subprocess() -> None:
         assert installed in result.stdout
     else:
         assert "unknown" in result.stdout
+
+
+# --- v3.5.0 manifest flags (issue #41) ---
+#
+# These tests run the CLI in-process (monkeypatched ``sys.argv``) with
+# ``urllib.request.urlopen`` stubbed, asserting the argparse-to-
+# ``downloader()`` wiring for the manifest flags end-to-end without
+# touching the network.
+
+
+class _FakeHttpResponse:
+    """Minimal stand-in for an ``urlopen`` response."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+        self.headers: dict = {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeHttpResponse":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+def _install_fake_bing(monkeypatch, image_count: int = 2) -> None:
+    """Stub ``urlopen`` to serve a canned Bing page and JPEG-ish bytes.
+
+    The page is identical on every fetch, so the second page yields no
+    new links and ``Bing.run()`` terminates after one page. Image bytes
+    start with the JPEG SOI marker so the real ``filetype`` validation
+    accepts them.
+    """
+
+    def fake_urlopen(request, timeout=None):
+        url = getattr(request, "full_url", request)
+        if "bing.com/images/async" in url:
+            body = "".join(
+                f"murl&quot;:&quot;https://img.test/{i}.jpg&quot;"
+                for i in range(1, image_count + 1)
+            ).encode()
+        else:
+            body = b"\xff\xd8\xff\xe0" + str(url).encode()
+        return _FakeHttpResponse(body)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+
+def _run_cli(monkeypatch, argv: list) -> None:
+    monkeypatch.setattr(sys, "argv", ["bbid"] + argv)
+    download.main()
+
+
+def _read_manifest(path):
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_cli_manifest_writes_default_jsonl(monkeypatch, tmp_path) -> None:
+    """``bbid --manifest`` writes <output_dir>/<query>/manifest.jsonl."""
+    _install_fake_bing(monkeypatch)
+    _run_cli(monkeypatch, ["red panda", "--limit", "2", "--manifest", "-d", str(tmp_path)])
+
+    records = _read_manifest(tmp_path / "red panda" / "manifest.jsonl")
+    assert len(records) == 2
+    for record in records:
+        assert record["status"] == "ok"
+        assert record["engine"] == "bing"
+        assert record["query"] == "red panda"
+    assert [r["index"] for r in records] == [1, 2]
+
+
+def test_cli_manifest_path_override(monkeypatch, tmp_path) -> None:
+    """``--manifest-path`` redirects the JSONL output."""
+    _install_fake_bing(monkeypatch)
+    override = tmp_path / "custom" / "out.jsonl"
+    _run_cli(
+        monkeypatch,
+        [
+            "red panda",
+            "--limit",
+            "2",
+            "--manifest",
+            "--manifest-path",
+            str(override),
+            "-d",
+            str(tmp_path / "imgs"),
+        ],
+    )
+
+    records = _read_manifest(override)
+    assert len(records) == 2
+
+
+def test_cli_manifest_fields_projection(monkeypatch, tmp_path) -> None:
+    """``--manifest-fields url,md5`` writes records with only those keys."""
+    _install_fake_bing(monkeypatch)
+    _run_cli(
+        monkeypatch,
+        [
+            "red panda",
+            "--limit",
+            "2",
+            "--manifest",
+            "--manifest-fields",
+            "url,md5",
+            "-d",
+            str(tmp_path),
+        ],
+    )
+
+    records = _read_manifest(tmp_path / "red panda" / "manifest.jsonl")
+    assert len(records) == 2
+    for record in records:
+        assert set(record) == {"url", "md5"}
+
+
+def test_cli_manifest_flush_every_reaches_writer(monkeypatch, tmp_path) -> None:
+    """``--manifest-flush-every 5`` is accepted and the run completes."""
+    _install_fake_bing(monkeypatch)
+    _run_cli(
+        monkeypatch,
+        [
+            "red panda",
+            "--limit",
+            "2",
+            "--manifest",
+            "--manifest-flush-every",
+            "5",
+            "-d",
+            str(tmp_path),
+        ],
+    )
+
+    records = _read_manifest(tmp_path / "red panda" / "manifest.jsonl")
+    assert len(records) == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ class _FakeHttpResponse:
     def read(self) -> bytes:
         return self._body
 
-    def __enter__(self) -> "_FakeHttpResponse":
+    def __enter__(self) -> _FakeHttpResponse:
         return self
 
     def __exit__(self, *exc) -> bool:
@@ -127,7 +127,9 @@ def test_cli_manifest_writes_default_jsonl(monkeypatch, tmp_path) -> None:
         assert record["status"] == "ok"
         assert record["engine"] == "bing"
         assert record["query"] == "red panda"
-    assert [r["index"] for r in records] == [1, 2]
+    # Downloads run in parallel, so records may be appended out of
+    # order; the indices themselves are strictly unique per search.
+    assert sorted(r["index"] for r in records) == [1, 2]
 
 
 def test_cli_manifest_path_override(monkeypatch, tmp_path) -> None:

--- a/tests/test_manifest_schema.py
+++ b/tests/test_manifest_schema.py
@@ -1,0 +1,123 @@
+"""Validate ``manifest.jsonl`` records against ``docs/manifest.schema.json``.
+
+Drift guard (issue #43): if the writer's output ever changes shape
+without the published schema being updated, these tests fail loudly.
+"""
+
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+from better_bing_image_downloader import Downloader  # noqa: E402
+from better_bing_image_downloader import base as _base  # noqa: E402
+from better_bing_image_downloader.base import ImageEngine  # noqa: E402
+
+SCHEMA_PATH = Path(__file__).resolve().parent.parent / "docs" / "manifest.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validator(schema: dict):
+    return jsonschema.Draft202012Validator(schema, format_checker=jsonschema.FormatChecker())
+
+
+def test_schema_is_valid_draft_2020_12(schema: dict) -> None:
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+def _run_manifest_search(tmp_path: Path) -> list[dict]:
+    """Run a real search (network stubbed) with manifest=True.
+
+    Produces one "ok" record and one "error" record through the real
+    writer code path.
+    """
+
+    class FakeEngine(ImageEngine):
+        def run(self) -> None:
+            self.download_image("https://example.test/good.jpg", 1)
+            self.download_image("https://example.test/bad.jpg", 2)
+
+    def fake_http_get(self, url, headers=None):
+        if "bad" in url:
+            raise urllib.error.URLError("boom")
+        return b"\xff\xd8\xff\xe0" + url.encode("utf-8")
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    dl = Downloader()
+    dl.register("fake", FakeEngine)
+    with patch.object(_base.ImageEngine, "_http_get", fake_http_get):
+        dl.search(
+            "cats",
+            limit=2,
+            engine="fake",
+            output_dir=tmp_path,
+            manifest=True,
+            manifest_path=str(manifest_path),
+        )
+
+    with open(manifest_path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def test_writer_output_validates_against_schema(schema: dict, tmp_path: Path) -> None:
+    records = _run_manifest_search(tmp_path)
+    assert len(records) == 2
+    statuses = sorted(r["status"] for r in records)
+    assert statuses == ["error", "ok"]
+
+    validator = _validator(schema)
+    for record in records:
+        errors = list(validator.iter_errors(record))
+        assert errors == [], f"record failed schema validation: {errors}"
+
+
+def test_skipped_record_validates_against_schema(schema: dict) -> None:
+    """A v3.6.0 min_dimension "skipped" record matches the schema."""
+    record = {
+        "index": 2,
+        "status": "skipped",
+        "url": "https://example.test/tiny.jpg",
+        "file": None,
+        "md5": None,
+        "error": "BelowMinDimension",
+        "engine": "bing",
+        "query": "cats",
+        "source_page": "https://www.bing.com/images/async?q=cats",
+        "downloaded_at": "2026-06-13T15:30:42Z",
+    }
+    errors = list(_validator(schema).iter_errors(record))
+    assert errors == [], f"skipped record failed schema validation: {errors}"
+
+
+def test_schema_covers_all_default_fields(schema: dict) -> None:
+    """Every DEFAULT_MANIFEST_FIELDS entry is declared in the schema."""
+    from better_bing_image_downloader.manifest import DEFAULT_MANIFEST_FIELDS
+
+    props = set(schema["properties"])
+    assert set(DEFAULT_MANIFEST_FIELDS) <= props
+    assert set(schema["required"]) == set(DEFAULT_MANIFEST_FIELDS)
+
+
+def test_schema_rejects_unknown_status(schema: dict) -> None:
+    record = {
+        "index": 1,
+        "status": "bogus",
+        "url": "https://example.test/a.jpg",
+        "file": "cats/Image_1.jpg",
+        "md5": "5d41402abc4b2a76b9719d911017c592",
+        "error": None,
+        "engine": "bing",
+        "query": "cats",
+        "source_page": None,
+        "downloaded_at": "2026-06-13T15:30:42Z",
+    }
+    assert not _validator(schema).is_valid(record)


### PR DESCRIPTION
Two issues, one commit each. **Stacked on #59** (it extends `tests/test_cli.py`, which #59 introduces); GitHub will retarget to `main` once #59 merges.

- **closes #41** — four new tests in `tests/test_cli.py` covering `--manifest`, `--manifest-path`, `--manifest-fields`, and `--manifest-flush-every`. They run the CLI in-process with monkeypatched `sys.argv` and a stubbed `urlopen` (canned Bing page + JPEG-magic bytes, so the real `filetype` validation runs), then assert on the manifest file state. Note: the issue suggested subprocess invocation; in-process was chosen because mocking the network boundary inside a subprocess requires a wrapper-script hack. `#33`'s subprocess test already covers the process-spawning path.
- **closes #43** — `docs/manifest.schema.json` (JSON Schema Draft 2020-12) covering all 10 default fields with nullability, the `ok`/`error`/`skipped` status enum, and the ISO 8601 UTC `downloaded_at` format. Referenced from the README manifest section and the `manifest.py` docstring. `tests/test_manifest_schema.py` validates real writer output (`ok` + `error` records from a stubbed-network search) and a synthesized `skipped` record against the schema, plus a check that the schema covers `DEFAULT_MANIFEST_FIELDS` exactly — writer/schema drift now fails loudly. `jsonschema>=4.0` added to dev extras + `requirements-dev.txt` (**test-only**, not a runtime dependency; the test uses `importorskip` for minimal environments, and CI installs `.[dev]` so it runs there).

No change to the writer itself — the schema describes what it already emits.

## Verification

- `pytest`: 229 passed, 2 skipped (network)
- `black`, `ruff`, `mypy`: all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the manifest record format and linked to its JSON Schema.
  * Clarified that failed downloads record their exception class names.
* **New Features**
  * Added a formal JSON Schema for validating manifest records.
  * Defined required fields, valid statuses, data types, and timestamp formatting.
* **Tests**
  * Added coverage for manifest generation, custom paths, field selection, flushing, skipped records, and failed downloads.
  * Added schema validation tests for valid and invalid manifest records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->