### PR TITLE
feat: deprecate the legacy _manifest.json file (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- The legacy `_manifest.json` file written by `downloader()` now emits
+  a `DeprecationWarning` and will be removed in v4.0.0. The file is
+  still written during the deprecation period. Migrate to the JSONL
+  `manifest.jsonl` export (`manifest=True`).
+
 ### Added
 
 - `crawler`, `helperdownload`, and `utils` now emit a

--- a/README.md
+++ b/README.md
@@ -420,7 +420,11 @@ downloader("cats", limit=150, output_dir="dataset")
 downloader("cats", limit=150, output_dir="dataset", engine="duckduckgo")
 ```
 
-### Download manifest (legacy)
+### Download manifest (legacy, deprecated)
+
+> **Deprecated:** `_manifest.json` is deprecated since v3.8.1 and will be
+> removed in v4.0.0. Use the JSONL `manifest.jsonl` export
+> (`manifest=True`, see above) for all new tooling.
 
 The legacy `downloader()` function also writes a `_manifest.json` file to the
 output directory after every run — a v3.1.x format kept for backwards

--- a/better_bing_image_downloader/download.py
+++ b/better_bing_image_downloader/download.py
@@ -204,7 +204,21 @@ def downloader(
 
 
 def _write_legacy_manifest(image_dir: Path, result) -> None:
-    """Write the v3.1.x-style _manifest.json. Best-effort, never raises."""
+    """Write the v3.1.x-style _manifest.json. Best-effort, never raises.
+
+    .. deprecated:: 3.8.1
+        The ``_manifest.json`` file is deprecated and will be removed in
+        v4.0.0. Use the JSONL ``manifest.jsonl`` export instead
+        (``manifest=True``).
+    """
+    warnings.warn(
+        "The _manifest.json file written by downloader() is deprecated and "
+        "will be removed in v4.0.0. Use the JSONL manifest instead: "
+        "downloader(..., manifest=True) or "
+        "Downloader().search(..., manifest=True).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         existing: dict = {}
         manifest_path = image_dir / "_manifest.json"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -136,3 +136,28 @@ def test_downloader_old_filter_param_works_with_deprecation_warning():
             downloader("cats", limit=1, output_dir=tmp, filter="photo")
         assert any(issubclass(x.category, DeprecationWarning) for x in w)
         assert any("image_filter" in str(x.message) for x in w)
+
+
+def test_legacy_manifest_write_emits_deprecation_warning():
+    """_manifest.json is deprecated (v3.8.1): warn, but still write the file."""
+    import warnings
+
+    tmp = tempfile.mkdtemp()
+    mock_cls = _build_mock_engine_cls(0)
+    with patch.object(
+        Downloader,
+        "_DEFAULT_REGISTRY",
+        {"bing": mock_cls, "duckduckgo": mock_cls},
+    ):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            downloader("cats", limit=1, output_dir=tmp)
+        manifest_warnings = [
+            x
+            for x in w
+            if issubclass(x.category, DeprecationWarning) and "_manifest.json" in str(x.message)
+        ]
+        assert manifest_warnings, "expected a DeprecationWarning about _manifest.json"
+        assert "v4.0.0" in str(manifest_warnings[0].message)
+    # The file is still written during the deprecation period.
+    assert os.path.exists(os.path.join(tmp, "cats", "_manifest.json"))


### PR DESCRIPTION
Takes option (b) from the issue: deprecate now, remove in v4.0.0.

- `_write_legacy_manifest` now emits a `DeprecationWarning` pointing users at the JSONL `manifest.jsonl` export (`manifest=True`). The file is **still written** during the deprecation period — no behavior removal.
- README's legacy manifest section is marked deprecated with a migration pointer.
- CHANGELOG gets a "Deprecated" entry.
- New test asserts the warning fires (and names v4.0.0) and that the file is still written.

This was the last open issue. After this merges, the v3.8.1 release can be cut from `main`.

## Verification

- `pytest`: 230 passed, 2 skipped (network)
- `black`, `ruff`, `mypy`: all clean