### PR TITLE
feat: capture image captions as image–text pairs (closes #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Image–text pairs**: the search engine's caption/title for each
+  image is now captured — Bing's `t` field and DuckDuckGo's `title`
+  field — and exposed on `ImageResult.caption` and as a new `caption`
+  field (the 11th) in `manifest.jsonl` records. `null` when the engine
+  provides no caption. `docs/manifest.schema.json` was updated to
+  match. Useful for building multimodal training datasets.
+
 ## [3.8.1] - 2026-08-23
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A fast, reliable Python library and CLI tool for bulk downloading images from Bi
 - **Embeddable `Downloader` API** — search programmatically with `Result` / `ImageResult` value objects, lifecycle hooks (`on_image`, `on_error`, `on_progress`, `on_engine_start`, `on_engine_done`), and `search_async` for asyncio code
 - **Two search engines, one API** — Bing (default) or DuckDuckGo, switched via a single `engine=` parameter
 - **JSONL manifest export** (`manifest=True`) — one record per download attempt, crash-safe, downstream-auditable
+- **Image–text pairs** — the search engine's title/caption for each image is recorded in the manifest and on `ImageResult.caption`, ready for multimodal dataset building
 - **`min_dimension` filter** — skip images smaller than N pixels on either side, useful for ML training data prep
 - **HTTP/HTTPS proxy support** — route all traffic through a proxy with a single `proxy=` parameter
 - **Cancel mid-run** via `CancelToken` — abort a `search()` cleanly without leaving partial state
@@ -351,7 +352,10 @@ Each line is a self-contained JSON object:
 Status values are `"ok"`, `"error"`, or `"skipped"`. The
 `source_page` field is the URL of the search-results page the
 image came from. Failed downloads record the typed exception
-class name in `error` (e.g. `"NetworkError"`). The record format
+class name in `error` (e.g. `"NetworkError"`). The `caption`
+field (v3.9.0+) carries the search engine's title/alt text for
+the image, so a manifest doubles as an image–text pair dataset.
+The record format
 is described by [`docs/manifest.schema.json`](docs/manifest.schema.json)
 (JSON Schema Draft 2020-12).
 

--- a/better_bing_image_downloader/base.py
+++ b/better_bing_image_downloader/base.py
@@ -360,6 +360,13 @@ class ImageEngine(ABC):
         # capture per-image provenance. ``None`` until the first page
         # fetch; remains ``None`` for engines that don't track it.
         self.last_page_url: str | None = None
+        # ``captions`` (v3.9.0+) maps image URL -> caption/title text
+        # supplied by the search backend (Bing's ``t`` field,
+        # DuckDuckGo's ``title`` field). Engines populate it during
+        # link extraction; ``Downloader.search`` copies it into
+        # ``ImageResult.caption`` and the manifest ``caption`` field.
+        # Empty for engines that don't surface captions.
+        self.captions: dict[str, str] = {}
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/better_bing_image_downloader/bing.py
+++ b/better_bing_image_downloader/bing.py
@@ -7,6 +7,8 @@ Improved Author: Krishnatejaswi S (shentharkrishnatejaswi@gmail.com)
 from __future__ import annotations
 
 import gzip
+import html as html_module
+import json
 import logging
 import re
 import time
@@ -174,6 +176,28 @@ class Bing(ImageEngine):
         """Extract ``murl`` image URLs from a Bing result page."""
         return re.findall(r"murl&quot;:&quot;(.*?)&quot;", html)
 
+    @staticmethod
+    def _extract_captions(html: str) -> dict[str, str]:
+        """Extract image captions (result titles) from a Bing result page.
+
+        Each result anchor carries an ``m`` attribute containing
+        HTML-escaped JSON with ``murl`` (image URL) and ``t`` (title)
+        fields. Returns a ``{murl: title}`` dict for results that have
+        both. Best-effort: blobs that fail to parse are skipped, and
+        results without a title simply don't appear in the dict.
+        """
+        captions: dict[str, str] = {}
+        for blob in re.findall(r'\bm="({.*?})"', html):
+            try:
+                meta = json.loads(html_module.unescape(blob))
+            except (ValueError, TypeError):
+                continue
+            url = meta.get("murl")
+            title = meta.get("t")
+            if url and title:
+                captions[url] = title
+        return captions
+
     def run(self) -> None:
         """Download images until ``self.limit`` is reached or pages are exhausted."""
         page_counter = 0
@@ -211,6 +235,7 @@ class Bing(ImageEngine):
                 break
 
             links = self._extract_links(html)
+            self.captions.update(self._extract_captions(html))
             if self.verbose:
                 logging.info(
                     "[%%] Indexed %d Images on Page %d.",

--- a/better_bing_image_downloader/downloader.py
+++ b/better_bing_image_downloader/downloader.py
@@ -614,6 +614,7 @@ class Downloader:
                 image_index=engine_obj.download_count,  # set by save_image
                 size_bytes=size,
                 mime_type=mime,
+                caption=getattr(engine_obj, "captions", {}).get(link),
             )
             images.append(ir)
             if self.on_image:
@@ -873,6 +874,11 @@ def _append_manifest_record(
             "query": manifest_ctx.query,
             "source_page": getattr(engine_obj, "last_page_url", None),
             "downloaded_at": _utcnow_iso(),
+            # ``caption`` (v3.9.0+): title/alt text from the search
+            # backend, looked up from the engine's captions dict.
+            # None for error/skipped records and engines without
+            # caption support.
+            "caption": getattr(engine_obj, "captions", {}).get(url),
         }
     )
 

--- a/better_bing_image_downloader/duckduckgo.py
+++ b/better_bing_image_downloader/duckduckgo.py
@@ -257,7 +257,13 @@ class DuckDuckGo(ImageEngine):
             data = json.loads(text)
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Failed to parse DuckDuckGo i.js response as JSON: {e}") from e
-        return [r["image"] for r in data.get("results", []) if r.get("image")]
+        results = data.get("results", [])
+        # v3.9.0+: capture per-result titles as captions for the
+        # manifest and ImageResult.caption.
+        for r in results:
+            if r.get("image") and r.get("title"):
+                self.captions[r["image"]] = r["title"]
+        return [r["image"] for r in results if r.get("image")]
 
     # --- Main loop ---
 

--- a/better_bing_image_downloader/manifest.py
+++ b/better_bing_image_downloader/manifest.py
@@ -18,7 +18,7 @@ Public surface:
 
 - :class:`ManifestWriter` — the writer
 - :class:`ManifestFieldError` — raised when an unknown field is requested
-- :data:`DEFAULT_MANIFEST_FIELDS` — the default 10-field set
+- :data:`DEFAULT_MANIFEST_FIELDS` — the default field set (11 fields)
 
 The on-disk record format is the public contract; it is described by
 ``docs/manifest.schema.json`` (JSON Schema Draft 2020-12) in the
@@ -35,7 +35,7 @@ from typing import IO, Any
 
 logger = logging.getLogger(__name__)
 
-# Default field set: "core + provenance" (10 fields).
+# Default field set: "core + provenance + caption" (11 fields).
 # These are the fields written to the manifest when the user does
 # not supply an explicit ``manifest_fields`` list. The order is
 # stable and is the on-disk schema; downstream tools can rely on it.
@@ -50,6 +50,7 @@ DEFAULT_MANIFEST_FIELDS: list[str] = [
     "query",
     "source_page",
     "downloaded_at",
+    "caption",
 ]
 
 

--- a/better_bing_image_downloader/results.py
+++ b/better_bing_image_downloader/results.py
@@ -44,6 +44,10 @@ class ImageResult(NamedTuple):
         Size of the saved file in bytes.
     mime_type : str
         Detected MIME type (``"image/jpeg"``, ``"image/png"`` etc.).
+    caption : str | None
+        Caption/title text supplied by the search backend for this
+        image (v3.9.0+). ``None`` when the engine did not provide one.
+        Useful for building image–text pair datasets.
     """
 
     path: Path
@@ -53,6 +57,7 @@ class ImageResult(NamedTuple):
     image_index: int
     size_bytes: int
     mime_type: str
+    caption: str | None = None
 
 
 class Result:

--- a/docs/manifest.schema.json
+++ b/docs/manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/KTS-o7/better_bing_image_downloader/main/docs/manifest.schema.json",
   "title": "better-bing-image-downloader manifest record",
-  "description": "One line of a manifest.jsonl file written by Downloader.search(manifest=True) (v3.5.0+). This schema describes a full record written with the default 10-field set (DEFAULT_MANIFEST_FIELDS). When a custom manifest_fields list is configured, each record is a projection of this schema containing only the requested fields.",
+  "description": "One line of a manifest.jsonl file written by Downloader.search(manifest=True) (v3.5.0+). This schema describes a full record written with the default field set (DEFAULT_MANIFEST_FIELDS; 10 fields in v3.5.0-v3.8.x, 11 fields from v3.9.0 with the addition of 'caption'). When a custom manifest_fields list is configured, each record is a projection of this schema containing only the requested fields.",
   "type": "object",
   "required": [
     "index",
@@ -14,7 +14,8 @@
     "engine",
     "query",
     "source_page",
-    "downloaded_at"
+    "downloaded_at",
+    "caption"
   ],
   "additionalProperties": false,
   "properties": {
@@ -59,6 +60,10 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO 8601 UTC timestamp, e.g. '2026-06-13T10:20:30Z'."
+    },
+    "caption": {
+      "type": ["string", "null"],
+      "description": "Caption/title text supplied by the search backend (Bing 't' field, DuckDuckGo 'title' field). Null when the engine did not provide one. Added in v3.9.0."
     }
   }
 }

--- a/tests/test_manifest_schema.py
+++ b/tests/test_manifest_schema.py
@@ -93,6 +93,7 @@ def test_skipped_record_validates_against_schema(schema: dict) -> None:
         "query": "cats",
         "source_page": "https://www.bing.com/images/async?q=cats",
         "downloaded_at": "2026-06-13T15:30:42Z",
+        "caption": "A tiny cat thumbnail",
     }
     errors = list(_validator(schema).iter_errors(record))
     assert errors == [], f"skipped record failed schema validation: {errors}"
@@ -119,5 +120,6 @@ def test_schema_rejects_unknown_status(schema: dict) -> None:
         "query": "cats",
         "source_page": None,
         "downloaded_at": "2026-06-13T15:30:42Z",
+        "caption": None,
     }
     assert not _validator(schema).is_valid(record)

--- a/tests/test_v3_5_0_manifest.py
+++ b/tests/test_v3_5_0_manifest.py
@@ -79,7 +79,7 @@ def test_writer_filters_to_configured_fields(tmp_path: Path) -> None:
 
 
 def test_writer_default_fields_are_core_plus_provenance(tmp_path: Path) -> None:
-    """The default field set is the 10 core+provenance fields, in the documented order."""
+    """The default field set is the documented core+provenance+caption fields, in order."""
     from better_bing_image_downloader.manifest import (
         DEFAULT_MANIFEST_FIELDS,
         ManifestWriter,
@@ -96,6 +96,7 @@ def test_writer_default_fields_are_core_plus_provenance(tmp_path: Path) -> None:
         "query",
         "source_page",
         "downloaded_at",
+        "caption",
     ]
 
     target = tmp_path / "manifest.jsonl"

--- a/tests/test_v3_9_0_captions.py
+++ b/tests/test_v3_9_0_captions.py
@@ -1,0 +1,160 @@
+"""Tests for v3.9.0 caption capture (image–text pairs).
+
+Bing surfaces a result title in the ``m`` attribute's JSON (``t``
+field); DuckDuckGo surfaces ``title`` in its ``i.js`` results. The
+caption flows into ``ImageResult.caption`` and the manifest's
+``caption`` field.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from better_bing_image_downloader import Downloader, ImageResult
+from better_bing_image_downloader.bing import Bing
+from better_bing_image_downloader.duckduckgo import DuckDuckGo
+
+
+def _bing_result_blob(url: str, title: str | None) -> str:
+    """Build one Bing result anchor with an HTML-escaped m JSON blob."""
+    meta = {"murl": url}
+    if title is not None:
+        meta["t"] = title
+    escaped = json.dumps(meta, separators=(",", ":")).replace('"', "&quot;")
+    return f'<a class="iusc" m="{escaped}">'
+
+
+class TestBingCaptionExtraction:
+    def test_extract_captions_parses_titles(self) -> None:
+        html = _bing_result_blob("https://img.test/1.jpg", "A red panda") + _bing_result_blob(
+            "https://img.test/2.jpg", "Red panda eating bamboo"
+        )
+        captions = Bing._extract_captions(html)
+        assert captions == {
+            "https://img.test/1.jpg": "A red panda",
+            "https://img.test/2.jpg": "Red panda eating bamboo",
+        }
+
+    def test_extract_captions_skips_results_without_title(self) -> None:
+        html = _bing_result_blob("https://img.test/1.jpg", None)
+        assert Bing._extract_captions(html) == {}
+
+    def test_extract_captions_tolerates_malformed_json(self) -> None:
+        html = '<a class="iusc" m="{&quot;murl&quot;:&quot;broken'
+        assert Bing._extract_captions(html) == {}
+
+    def test_extract_links_unchanged_by_caption_support(self) -> None:
+        html = _bing_result_blob("https://img.test/1.jpg", "A red panda")
+        assert Bing._extract_links(html) == ["https://img.test/1.jpg"]
+
+
+class TestDuckDuckGoCaptionExtraction:
+    @patch("urllib.request.build_opener")
+    def test_fetch_page_populates_captions(self, mock_build_opener, tmp_path) -> None:
+        payload = {
+            "results": [
+                {"image": "https://example.com/a.jpg", "title": "Cat on a mat"},
+                {"image": "https://example.com/b.png"},  # no title
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(payload).encode()
+        mock_resp.headers.get.return_value = ""
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_opener = MagicMock()
+        mock_opener.open.return_value = mock_resp
+        mock_build_opener.return_value = mock_opener
+
+        d = DuckDuckGo("cats", 10, str(tmp_path))
+        urls = d._fetch_page("vqd-token", 0)
+
+        assert urls == ["https://example.com/a.jpg", "https://example.com/b.png"]
+        assert d.captions == {"https://example.com/a.jpg": "Cat on a mat"}
+
+
+class _FakeHttpResponse:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+        self.headers: dict = {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeHttpResponse:
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+class TestCaptionEndToEnd:
+    def test_caption_reaches_image_result_and_manifest(self, monkeypatch, tmp_path) -> None:
+        """A full Bing search (network stubbed) puts captions into both
+        ImageResult objects and manifest.jsonl records."""
+
+        def fake_urlopen(request, timeout=None):
+            url = getattr(request, "full_url", request)
+            if "bing.com/images/async" in url:
+                body = (
+                    _bing_result_blob("https://img.test/1.jpg", "A red panda")
+                    + _bing_result_blob("https://img.test/2.jpg", "Red panda eating bamboo")
+                ).encode()
+            else:
+                body = b"\xff\xd8\xff\xe0" + str(url).encode()
+            return _FakeHttpResponse(body)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        seen: list[ImageResult] = []
+        dl = Downloader()
+        dl.on_image = seen.append
+        result = dl.search("red panda", limit=2, output_dir=tmp_path, manifest=True)
+
+        assert result.count == 2
+        captions = sorted(img.caption for img in seen)
+        assert captions == ["A red panda", "Red panda eating bamboo"]
+
+        assert result.manifest_path is not None
+        with open(result.manifest_path, encoding="utf-8") as f:
+            records = [json.loads(line) for line in f if line.strip()]
+        assert len(records) == 2
+        assert sorted(r["caption"] for r in records) == [
+            "A red panda",
+            "Red panda eating bamboo",
+        ]
+
+    def test_caption_is_none_when_engine_provides_none(self, monkeypatch, tmp_path) -> None:
+        """Pages without title metadata still work; caption is null."""
+
+        def fake_urlopen(request, timeout=None):
+            url = getattr(request, "full_url", request)
+            if "bing.com/images/async" in url:
+                body = _bing_result_blob("https://img.test/1.jpg", None).encode()
+            else:
+                body = b"\xff\xd8\xff\xe0" + str(url).encode()
+            return _FakeHttpResponse(body)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        result = Downloader().search("red panda", limit=1, output_dir=tmp_path, manifest=True)
+        assert result.count == 1
+        assert result.images[0].caption is None
+
+
+class TestImageResultBackwardsCompat:
+    def test_image_result_default_caption_is_none(self, tmp_path: Path) -> None:
+        """Constructing ImageResult with the pre-3.9.0 7-arg form works."""
+        ir = ImageResult(
+            path=tmp_path / "Image_1.jpg",
+            source_url="https://example.com/a.jpg",
+            engine="bing",
+            query="cats",
+            image_index=1,
+            size_bytes=10,
+            mime_type="image/jpeg",
+        )
+        assert ir.caption is None


### PR DESCRIPTION
Implements #62: the search engine's caption/title for each image is now captured instead of discarded.

## What changed

- **Bing**: new `_extract_captions()` parses the `m` attribute's HTML-escaped JSON for `murl` + `t` (title). Best-effort — malformed blobs are skipped, results without titles simply have no caption. `_extract_links()` is untouched (same regex, same behavior).
- **DuckDuckGo**: `_fetch_page` records each result's `title` into the captions dict.
- **Base**: `ImageEngine.__init__` gains `self.captions: dict[str, str]` (URL → caption).
- **Plumbing**: `ImageResult.caption` (new trailing NamedTuple field, default `None` — existing 7-arg construction still works) and a new `caption` field appended to `DEFAULT_MANIFEST_FIELDS` (11th, nullable).
- **Schema**: `docs/manifest.schema.json` updated in the same PR — `caption` added to `properties` and `required`; the drift test keeps writer and schema in lockstep.

No new dependencies, no signature breakage, no CLI changes needed (captions appear in the manifest automatically).

## Tests

New `tests/test_v3_9_0_captions.py` (8 tests): Bing blob parsing (incl. malformed/missing titles), DDG title capture, two end-to-end stubbed-network searches asserting captions land in both `ImageResult` and `manifest.jsonl`, and an `ImageResult` backwards-compat test.

## Verification

- `pytest`: 238 passed, 2 skipped (network)
- `black`, `ruff`, `mypy`: all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image search results now include captions or titles from Bing and DuckDuckGo.
  - Captions are available through `ImageResult.caption`.
  - Manifest files now include an 11th `caption` field, using `null` when unavailable.
  - Caption data supports image–text dataset workflows.

- **Documentation**
  - Updated the README, changelog, and manifest schema to document caption support and version compatibility.

- **Bug Fixes**
  - Improved handling of missing, empty, or malformed caption metadata without disrupting image results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->