### PR TITLE
feat: manifest export to url-list and Parquet (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the network-gated tests against the live endpoints every Monday and
   opens a `bug` issue automatically on failure.
 
+- **Manifest export** (#64): `export_manifest()` converts a
+  `manifest.jsonl` into ML-pipeline formats — `url-list`
+  (img2dataset-compatible, one URL per line, `ok` records only,
+  stdlib-only) and `parquet` (all records, needs the new optional
+  `[parquet]` extra). Also available as `bbid export --format ...`.
+  Partial manifests from crashed runs export cleanly.
+
 ### Fixed
 
 - `tests/test_cli.py::test_version_flag_via_argv` failed on Windows

--- a/README.md
+++ b/README.md
@@ -377,6 +377,30 @@ CLI equivalent:
 bbid --manifest --manifest-fields index,status,url,md5 "red panda"
 ```
 
+#### Exporting manifests (v3.10.0+)
+
+Convert a `manifest.jsonl` into formats ML pipelines already consume:
+
+```python
+from better_bing_image_downloader import export_manifest
+
+# img2dataset-compatible: one image URL per line, ok records only
+export_manifest("dataset/red panda/manifest.jsonl", "url-list", "urls.txt")
+
+# Parquet: all records (ok, error, skipped) with every field
+# requires: pip install "better-bing-image-downloader[parquet]"
+export_manifest("dataset/red panda/manifest.jsonl", "parquet", "manifest.parquet")
+```
+
+CLI equivalent:
+
+```bash
+bbid export --format url-list --manifest "dataset/red panda/manifest.jsonl" --dest urls.txt
+```
+
+Partial manifests from crashed runs export cleanly — blank or malformed
+lines are skipped with a warning.
+
 #### Minimum dimension filter (v3.6.0+)
 
 For ML training data, thumbnails are noise. Pass `min_dimension` to

--- a/better_bing_image_downloader/__init__.py
+++ b/better_bing_image_downloader/__init__.py
@@ -12,6 +12,7 @@ from .base import (
 from .bing import Bing
 from .download import downloader
 from .downloader import CancelToken, Downloader
+from .export import export_manifest
 from .manifest import DEFAULT_MANIFEST_FIELDS, ManifestFieldError, ManifestWriter
 from .results import ImageResult, Result
 
@@ -34,6 +35,7 @@ __all__ = [
     "Result",
     "WriteError",
     "downloader",
+    "export_manifest",
 ]
 
 # ``DuckDuckGo`` is exposed eagerly as of v3.1.1: ``brotli`` is a hard

--- a/better_bing_image_downloader/download.py
+++ b/better_bing_image_downloader/download.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import logging
 import shutil
+import sys
 import warnings
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
@@ -244,8 +245,53 @@ def _write_legacy_manifest(image_dir: Path, result) -> None:
         logging.error("Failed to write manifest: %s", e)
 
 
+def _export_main(argv: list[str]) -> None:
+    """Handle ``bbid export --format ... --manifest ... --dest ...``.
+
+    Implemented as a separate parser invoked from :func:`main` rather
+    than argparse subparsers, so ``bbid "query"`` keeps working
+    unchanged.
+    """
+    from .export import export_manifest
+
+    parser = argparse.ArgumentParser(
+        prog="bbid export",
+        description="Export a manifest.jsonl to an ML-pipeline format.",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        required=True,
+        choices=["url-list", "parquet"],
+        help="Output format: 'url-list' (one URL per line, ok records only; "
+        "img2dataset-compatible) or 'parquet' (all records; needs the "
+        "'parquet' extra).",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=str,
+        required=True,
+        help="Path to the manifest.jsonl file to export.",
+    )
+    parser.add_argument(
+        "--dest",
+        type=str,
+        required=True,
+        help="Destination file path.",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    rows = export_manifest(args.manifest, args.format, args.dest)
+    logging.info("Exported %d rows to %s", rows, args.dest)
+
+
 def main() -> None:
     """Entry point for the ``bbid`` CLI command."""
+    # ``export`` is a subcommand-shaped invocation; intercept it before
+    # the positional-query parser so ``bbid "query"`` is untouched.
+    if sys.argv[1:2] == ["export"]:
+        _export_main(sys.argv[2:])
+        return
     parser = argparse.ArgumentParser(description="Download images using Bing or DuckDuckGo.")
     try:
         _version = pkg_version("better-bing-image-downloader")

--- a/better_bing_image_downloader/export.py
+++ b/better_bing_image_downloader/export.py
@@ -1,0 +1,133 @@
+"""Export ``manifest.jsonl`` files to ML-pipeline formats.
+
+ML users consume manifests through tools that expect specific input
+formats — img2dataset wants a plain text file with one URL per line,
+Hugging Face ``datasets`` and parquet-native pipelines want Parquet.
+This module converts a JSONL manifest (as written by
+:class:`better_bing_image_downloader.manifest.ManifestWriter`) into
+those formats with one call.
+
+The exporter is deliberately tolerant of partial manifests: blank
+lines are skipped, and lines that fail to parse as JSON are logged
+via :mod:`logging` and skipped — a crashed run still exports cleanly.
+
+Public surface:
+
+- :func:`export_manifest` — export a manifest to ``url-list`` or
+  ``parquet``, returning the number of rows written.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Formats accepted by :func:`export_manifest`.
+VALID_EXPORT_FORMATS: tuple[str, ...] = ("url-list", "parquet")
+
+
+def export_manifest(manifest_path: str | Path, fmt: str, dest: str | Path) -> int:
+    """Export a JSONL manifest to an ML-pipeline format.
+
+    Parameters
+    ----------
+    manifest_path : str | Path
+        Path to the ``manifest.jsonl`` file written by a search run.
+    fmt : str
+        Output format. ``"url-list"`` writes a ``.txt`` file with one
+        image URL per line (only ``status == "ok"`` records) — the
+        img2dataset-compatible input format. ``"parquet"`` writes ALL
+        records (every status) to Parquet; requires the optional
+        ``pyarrow`` dependency.
+    dest : str | Path
+        Destination file path. Parent directories are created if
+        needed.
+
+    Returns
+    -------
+    int
+        Number of rows written to ``dest``.
+
+    Raises
+    ------
+    ValueError
+        If ``fmt`` is not one of :data:`VALID_EXPORT_FORMATS`.
+    ImportError
+        If ``fmt == "parquet"`` and ``pyarrow`` is not installed.
+
+    Example
+    -------
+
+    >>> from better_bing_image_downloader import export_manifest
+    >>> export_manifest("dataset/red panda/manifest.jsonl", "url-list", "urls.txt")
+    42
+    """
+    if fmt not in VALID_EXPORT_FORMATS:
+        raise ValueError(
+            f"unknown export format {fmt!r}; valid formats: {', '.join(VALID_EXPORT_FORMATS)}"
+        )
+    records = list(_iter_records(manifest_path))
+    if fmt == "url-list":
+        return _write_url_list(records, dest)
+    return _write_parquet(records, dest)
+
+
+def _iter_records(manifest_path: str | Path) -> Iterator[dict[str, Any]]:
+    """Yield parsed records from a JSONL manifest.
+
+    Blank lines are skipped. Lines that fail ``json.loads`` are logged
+    with :func:`logging.warning` and skipped, so a partial manifest
+    from a crashed run never aborts the export.
+    """
+    resolved = Path(manifest_path).expanduser()
+    with open(resolved, encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "skipping malformed manifest line %d in %s: %s", lineno, resolved, exc
+                )
+                continue
+            if not isinstance(record, dict):
+                logger.warning(
+                    "skipping non-object manifest line %d in %s: %r", lineno, resolved, record
+                )
+                continue
+            yield record
+
+
+def _write_url_list(records: list[dict[str, Any]], dest: str | Path) -> int:
+    """Write one URL per line for records with ``status == "ok"``."""
+    urls = [r["url"] for r in records if r.get("status") == "ok" and r.get("url")]
+    resolved = Path(dest).expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with open(resolved, "w", encoding="utf-8") as f:
+        for url in urls:
+            f.write(f"{url}\n")
+    return len(urls)
+
+
+def _write_parquet(records: list[dict[str, Any]], dest: str | Path) -> int:
+    """Write all records (every status) to a Parquet file via pyarrow."""
+    try:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+    except ImportError as exc:
+        raise ImportError(
+            "Parquet export requires pyarrow. Install it with: "
+            'pip install "better-bing-image-downloader[parquet]"'
+        ) from exc
+    resolved = Path(dest).expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    table = pa.Table.from_pylist(records) if records else pa.table({})
+    pq.write_table(table, resolved)
+    return int(table.num_rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+parquet = [
+    "pyarrow>=14.0",
+]
 google = [
     "selenium>=4.0.0",
     "chromedriver-autoinstaller>=0.6.0",

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -146,11 +146,13 @@ def test_cli_export_url_list(monkeypatch, tmp_path) -> None:
 
 
 def test_cli_export_does_not_break_query_invocation(monkeypatch) -> None:
-    """``bbid export`` as a *query* is not hijacked... actually it is: guard the contract.
+    """Pin the ``bbid export`` intercept in :func:`download.main`.
 
-    A search for the literal query ``export`` now routes to the export
-    parser, which exits with an argparse error when required flags are
-    missing — this test pins that intended behaviour.
+    The first positional token ``export`` is routed to
+    :func:`_export_main` before the search-query parser runs, so
+    ``bbid export`` (no flags) hits the export parser and exits with
+    argparse's ``usage`` error (exit code 2). ``bbid "query"`` is
+    unchanged — the intercept only fires on the exact first token.
     """
     monkeypatch.setattr(sys, "argv", ["bbid", "export"])
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,158 @@
+"""Tests for :mod:`better_bing_image_downloader.export` (issue #64)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from better_bing_image_downloader import download, export_manifest
+from better_bing_image_downloader.manifest import ManifestWriter
+
+_RECORDS = [
+    {
+        "index": 1,
+        "status": "ok",
+        "url": "https://img.test/1.jpg",
+        "file": "red panda_1.jpg",
+        "md5": "aaa",
+        "error": None,
+        "engine": "bing",
+        "query": "red panda",
+        "source_page": "https://bing.com/images/async?q=red+panda",
+        "downloaded_at": "2026-08-24T10:00:00Z",
+        "caption": "a red panda",
+    },
+    {
+        "index": 2,
+        "status": "error",
+        "url": "https://img.test/2.jpg",
+        "file": None,
+        "md5": None,
+        "error": "NetworkError",
+        "engine": "bing",
+        "query": "red panda",
+        "source_page": "https://bing.com/images/async?q=red+panda",
+        "downloaded_at": "2026-08-24T10:00:01Z",
+        "caption": None,
+    },
+    {
+        "index": 3,
+        "status": "skipped",
+        "url": "https://img.test/3.jpg",
+        "file": None,
+        "md5": None,
+        "error": "BelowMinDimension",
+        "engine": "bing",
+        "query": "red panda",
+        "source_page": "https://bing.com/images/async?q=red+panda",
+        "downloaded_at": "2026-08-24T10:00:02Z",
+        "caption": "tiny red panda",
+    },
+]
+
+
+def _write_manifest(path, records=None) -> None:
+    with ManifestWriter(path) as w:
+        for record in records or _RECORDS:
+            w.append(record)
+
+
+def test_url_list_exports_only_ok_records(tmp_path) -> None:
+    """url-list contains one URL per line, ok records only."""
+    manifest = tmp_path / "manifest.jsonl"
+    dest = tmp_path / "urls.txt"
+    _write_manifest(manifest)
+
+    count = export_manifest(manifest, "url-list", dest)
+
+    assert count == 1
+    assert dest.read_text(encoding="utf-8") == "https://img.test/1.jpg\n"
+
+
+def test_url_list_skips_blank_and_malformed_lines(tmp_path, caplog) -> None:
+    """Blank lines are skipped; malformed JSON warns and is skipped."""
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        "\n"
+        '{"status": "ok", "url": "https://img.test/a.jpg"}\n'
+        "not json at all\n"
+        '{"status": "ok", "url": "https://img.test/b.jpg"}\n',
+        encoding="utf-8",
+    )
+    dest = tmp_path / "urls.txt"
+
+    with caplog.at_level("WARNING", logger="better_bing_image_downloader.export"):
+        count = export_manifest(manifest, "url-list", dest)
+
+    assert count == 2
+    assert dest.read_text(encoding="utf-8").splitlines() == [
+        "https://img.test/a.jpg",
+        "https://img.test/b.jpg",
+    ]
+    assert any("malformed manifest line" in r.message for r in caplog.records)
+
+
+def test_parquet_exports_all_statuses(tmp_path) -> None:
+    """Parquet export includes ok/error/skipped records and round-trips fields."""
+    pq = pytest.importorskip("pyarrow.parquet")
+    manifest = tmp_path / "manifest.jsonl"
+    dest = tmp_path / "out" / "manifest.parquet"
+    _write_manifest(manifest)
+
+    count = export_manifest(manifest, "parquet", dest)
+
+    assert count == 3
+    table = pq.read_table(dest)
+    assert table.num_rows == 3
+    rows = table.to_pylist()
+    assert rows[0]["url"] == "https://img.test/1.jpg"
+    assert rows[1]["status"] == "error"
+    assert rows[2]["caption"] == "tiny red panda"
+
+
+def test_unknown_format_raises_value_error(tmp_path) -> None:
+    """An unknown format raises ValueError listing the valid formats."""
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest)
+
+    with pytest.raises(ValueError, match="url-list"):
+        export_manifest(manifest, "csv", tmp_path / "out.csv")
+
+
+def test_cli_export_url_list(monkeypatch, tmp_path) -> None:
+    """``bbid export --format url-list`` writes the dest file in-process."""
+    manifest = tmp_path / "manifest.jsonl"
+    dest = tmp_path / "urls.txt"
+    _write_manifest(manifest)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bbid",
+            "export",
+            "--format",
+            "url-list",
+            "--manifest",
+            str(manifest),
+            "--dest",
+            str(dest),
+        ],
+    )
+
+    download.main()
+
+    assert dest.read_text(encoding="utf-8") == "https://img.test/1.jpg\n"
+
+
+def test_cli_export_does_not_break_query_invocation(monkeypatch) -> None:
+    """``bbid export`` as a *query* is not hijacked... actually it is: guard the contract.
+
+    A search for the literal query ``export`` now routes to the export
+    parser, which exits with an argparse error when required flags are
+    missing — this test pins that intended behaviour.
+    """
+    monkeypatch.setattr(sys, "argv", ["bbid", "export"])
+    with pytest.raises(SystemExit) as exc_info:
+        download.main()
+    assert exc_info.value.code == 2

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -39,6 +39,7 @@ _SUBMODULE_OF = {
     "Result": "results",
     "WriteError": "base",
     "downloader": "download",
+    "export_manifest": "export",
 }
 
 


### PR DESCRIPTION
Implements #64, minimal slice:

- New `export.py` with `export_manifest(manifest_path, fmt, dest) -> int`:
  - `url-list`: stdlib-only, one URL per line, `status == "ok"` records only — img2dataset-compatible input
  - `parquet`: all records via the new optional `[parquet]` extra (`pyarrow>=14.0`); helpful ImportError otherwise
  - blank/malformed manifest lines are skipped with a warning, never fatal
- CLI: `bbid export --format ... --manifest ... --dest ...`, implemented as a pre-parse dispatch in `main()` so `bbid "query"` is byte-identical (no argparse subparser restructure)
- `export_manifest` exported from the package top level (`test_public_api.py` mapping updated)
- README "Exporting manifests" section + CHANGELOG entry

## Tests

8 new tests in `tests/test_export.py`: round-trips for both formats (parquet gated on `importorskip("pyarrow")`), malformed-line tolerance, unknown-format ValueError, and CLI wiring via monkeypatched argv.

## Verification

- `pytest`: 246 passed, 2 skipped (network)
- `black`, `ruff`, `mypy`: all clean