### PR TITLE
feat: MCP server for LLM agent image search (closes #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stdlib-only) and `parquet` (all records, needs the new optional
   `[parquet]` extra). Also available as `bbid export --format ...`.
   Partial manifests from crashed runs export cleanly.
+- **MCP server** (#65): `bbid-mcp` serves a `search_images` tool over
+  stdio so LLM agents (Claude Code/Desktop, LangGraph) can trigger
+  image collection. Requires the new optional `[mcp]` extra. Searches
+  are serialized with a lock and each call uses a fresh `Downloader`,
+  per the documented thread-safety contract.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,33 @@ downloader("cats", filter="photo")
 downloader("cats", image_filter="photo")
 ```
 
+## MCP server (LLM agents)
+
+LLM agents (Claude Code/Desktop, LangGraph, …) can trigger image
+collection over the Model Context Protocol. Install the extra and run
+the stdio server:
+
+```bash
+pip install "better-bing-image-downloader[mcp]"
+bbid-mcp
+```
+
+Claude Desktop / Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "bbid": { "command": "bbid-mcp" }
+  }
+}
+```
+
+The server exposes one tool, `search_images(query, limit, engine,
+output_dir, manifest)`, which downloads images and returns a summary
+dict with `count`, `output_dir`, `manifest_path`, `skipped`, and
+`errors`. Searches are serialized and each call uses a fresh
+`Downloader`, per the thread-safety contract.
+
 ## CLI — bbid
 
 The `bbid` command is installed automatically with the package:

--- a/better_bing_image_downloader/mcp_server.py
+++ b/better_bing_image_downloader/mcp_server.py
@@ -16,15 +16,24 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Any
 
 from .downloader import Downloader
 
+# ``FastMCP`` is provided by the optional ``mcp`` package (1.x — see
+# ``[project.optional-dependencies] mcp``). Decoupling the runtime symbol
+# from the import lets mypy see ``FastMCP`` as ``Any`` regardless of which
+# branch ran, and dodges ``[unused-ignore]`` lint errors when ``mcp`` is
+# installed in a dev/CI environment.
+FastMCP: Any
+
 try:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.fastmcp import FastMCP as _fastmcp_real
+
+    FastMCP = _fastmcp_real
 
     _HAS_MCP = True
 except ImportError:  # pragma: no cover
-    FastMCP = None  # type: ignore[misc, assignment]
     _HAS_MCP = False
 
 __all__ = ["main"]

--- a/better_bing_image_downloader/mcp_server.py
+++ b/better_bing_image_downloader/mcp_server.py
@@ -1,0 +1,146 @@
+"""MCP server exposing image search to LLM agents (issue #65).
+
+LLM agents (Claude Code/Desktop, LangGraph, ...) call tools over the
+Model Context Protocol. This module wraps :class:`Downloader.search` in
+a single MCP tool, ``search_images``, served over stdio by the
+``bbid-mcp`` console script.
+
+The ``mcp`` package is an **optional** dependency (install with
+``pip install "better-bing-image-downloader[mcp]"``). This module is
+importable without it: the import is guarded the same way
+``duckduckgo.py`` guards ``brotli``, and the entry point fails with a
+helpful message only when the server is actually started.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from .downloader import Downloader
+
+try:
+    from mcp.server.fastmcp import FastMCP
+
+    _HAS_MCP = True
+except ImportError:  # pragma: no cover
+    FastMCP = None  # type: ignore[misc, assignment]
+    _HAS_MCP = False
+
+__all__ = ["main"]
+
+logger = logging.getLogger(__name__)
+
+_MCP_MISSING_MSG = (
+    "The 'mcp' package is required to run the bbid MCP server. "
+    'Install it with `pip install "better-bing-image-downloader[mcp]"`.'
+)
+
+# Serializes searches across MCP tool calls. ``Downloader`` instances
+# are not safe to share across threads when ``manifest=True`` (the
+# underlying ``ManifestWriter`` is single-threaded), so each call also
+# constructs a fresh ``Downloader()`` — the lock additionally prevents
+# two concurrent searches from racing on the same ``output_dir``.
+_SEARCH_LOCK = threading.Lock()
+
+
+def _run_search(
+    query: str,
+    limit: int = 10,
+    engine: str = "bing",
+    output_dir: str = "dataset",
+    manifest: bool = True,
+) -> dict:
+    """Run one image search and return a JSON-serializable summary dict.
+
+    This is the core of the MCP ``search_images`` tool, kept free of any
+    ``mcp`` imports so it can be tested (and reused) without the
+    optional dependency installed.
+
+    Returns
+    -------
+    dict
+        ``{"count": int, "output_dir": str, "manifest_path": str | None,
+        "skipped": int, "errors": int}``.
+    """
+    with _SEARCH_LOCK:
+        result = Downloader().search(
+            query=query,
+            limit=limit,
+            engine=engine,
+            output_dir=output_dir,
+            manifest=manifest,
+        )
+    summary = {
+        "count": result.count,
+        "output_dir": str(result.output_dir),
+        "manifest_path": result.manifest_path,
+        "skipped": result.skipped,
+        "errors": len(result.errors),
+    }
+    logger.info(
+        "MCP search_images: query=%r engine=%r count=%d skipped=%d errors=%d",
+        query,
+        engine,
+        summary["count"],
+        summary["skipped"],
+        summary["errors"],
+    )
+    return summary
+
+
+def _build_server() -> FastMCP:
+    """Create the FastMCP server and register the ``search_images`` tool.
+
+    Raises
+    ------
+    RuntimeError
+        If the optional ``mcp`` package is not installed.
+    """
+    if not _HAS_MCP:
+        raise RuntimeError(_MCP_MISSING_MSG)
+    server = FastMCP("bbid")
+
+    @server.tool()
+    def search_images(
+        query: str,
+        limit: int = 10,
+        engine: str = "bing",
+        output_dir: str = "dataset",
+        manifest: bool = True,
+    ) -> dict:
+        """Search Bing or DuckDuckGo for images and download them to disk.
+
+        Args:
+            query: Search term (e.g. "red panda").
+            limit: Maximum number of images to download.
+            engine: Search engine to use: "bing" or "duckduckgo".
+            output_dir: Base output directory; images land in
+                ``<output_dir>/<query>/``.
+            manifest: Write a JSONL ``manifest.jsonl` recording every
+                attempted download (success or failure).
+
+        Returns:
+            A summary dict with keys ``count``, ``output_dir``,
+            ``manifest_path``, ``skipped`` and ``errors``.
+        """
+        return _run_search(
+            query=query,
+            limit=limit,
+            engine=engine,
+            output_dir=output_dir,
+            manifest=manifest,
+        )
+
+    return server
+
+
+def main() -> None:
+    """Console-script entry point for ``bbid-mcp``: serve MCP over stdio."""
+    if not _HAS_MCP:
+        raise SystemExit(_MCP_MISSING_MSG)
+    _build_server().run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.5",
     "jsonschema>=4.0",
+    "mcp>=1.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
 parquet = [
     "pyarrow>=14.0",
 ]
+mcp = [
+    "mcp>=1.0",
+]
 google = [
     "selenium>=4.0.0",
     "chromedriver-autoinstaller>=0.6.0",
@@ -55,6 +58,7 @@ dev = [
 
 [project.scripts]
 bbid = "better_bing_image_downloader.download:main"
+bbid-mcp = "better_bing_image_downloader.mcp_server:main"
 
 [project.urls]
 Homepage = "https://github.com/KTS-o7/better_bing_image_downloader"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ parquet = [
     "pyarrow>=14.0",
 ]
 mcp = [
-    "mcp>=1.0",
+    "mcp>=1.0,<2; python_version >= '3.10'",
 ]
 google = [
     "selenium>=4.0.0",
@@ -54,7 +54,7 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.5",
     "jsonschema>=4.0",
-    "mcp>=1.0",
+    "mcp>=1.0,<2; python_version >= '3.10'",
 ]
 
 [project.scripts]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,104 @@
+"""Tests for the optional MCP server (issue #65).
+
+The core ``_run_search`` helper is testable without the ``mcp``
+package; the FastMCP wiring test is skipped when ``mcp`` is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from better_bing_image_downloader import mcp_server
+
+
+def _fake_result(count: int = 3, skipped: int = 1, errors: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.count = count
+    result.output_dir = Path("dataset/cats")
+    result.manifest_path = "dataset/cats/manifest.jsonl"
+    result.skipped = skipped
+    result.errors = [("https://x/bad.jpg", ValueError("boom"))] * errors
+    return result
+
+
+class TestRunSearchHelper:
+    def test_summary_dict_shape(self, tmp_path) -> None:
+        with patch.object(
+            mcp_server.Downloader, "search", return_value=_fake_result()
+        ) as mock_search:
+            summary = mcp_server._run_search("cats", limit=5, output_dir=str(tmp_path))
+
+        assert summary == {
+            "count": 3,
+            "output_dir": "dataset/cats",
+            "manifest_path": "dataset/cats/manifest.jsonl",
+            "skipped": 1,
+            "errors": 0,
+        }
+        # Parameters are forwarded to Downloader.search as kwargs.
+        _, kwargs = mock_search.call_args
+        assert kwargs["query"] == "cats"
+        assert kwargs["limit"] == 5
+        assert kwargs["engine"] == "bing"
+        assert kwargs["manifest"] is True
+
+    def test_manifest_false_by_request(self, tmp_path) -> None:
+        fake = _fake_result()
+        fake.manifest_path = None
+        with patch.object(mcp_server.Downloader, "search", return_value=fake) as mock_search:
+            summary = mcp_server._run_search("cats", manifest=False)
+        assert summary["manifest_path"] is None
+        assert mock_search.call_args.kwargs["manifest"] is False
+
+    def test_sequential_calls_are_serialized_and_independent(self) -> None:
+        """Two calls each construct a fresh Downloader and both succeed."""
+        with patch.object(mcp_server, "Downloader") as mock_dl:
+            mock_dl.return_value.search.side_effect = [_fake_result(1), _fake_result(2)]
+            first = mcp_server._run_search("cats")
+            second = mcp_server._run_search("dogs")
+        assert first["count"] == 1
+        assert second["count"] == 2
+        # Fresh Downloader per call (thread-safety contract).
+        assert mock_dl.call_count == 2
+
+
+class TestOptionalDependencyHandling:
+    def test_module_importable_without_mcp(self) -> None:
+        """Importing mcp_server must not fail when ``mcp`` is absent."""
+        with patch.dict(
+            sys.modules,
+            {"mcp": None, "mcp.server": None, "mcp.server.fastmcp": None},
+        ):
+            importlib.reload(mcp_server)
+            assert mcp_server._HAS_MCP is False
+            with pytest.raises(SystemExit):
+                mcp_server.main()
+        importlib.reload(mcp_server)  # restore real state
+
+    def test_build_server_raises_without_mcp(self) -> None:
+        with (
+            patch.object(mcp_server, "_HAS_MCP", False),
+            pytest.raises(RuntimeError, match="mcp"),
+        ):
+            mcp_server._build_server()
+
+
+class TestFastMCPWiring:
+    @pytest.fixture(autouse=True)
+    def _require_mcp(self):
+        pytest.importorskip("mcp", reason="optional [mcp] extra not installed")
+
+    def test_server_builds_and_registers_tool(self) -> None:
+        server = mcp_server._build_server()
+        assert server.name == "bbid"
+
+    def test_tool_is_registered(self) -> None:
+        server = mcp_server._build_server()
+        # FastMCP >= 1.x exposes registered tools via the tool manager.
+        tools = server._tool_manager.list_tools()
+        assert any(t.name == "search_images" for t in tools)


### PR DESCRIPTION
Implements #65:

- New `mcp_server.py`: a FastMCP server (name `bbid`) exposing one tool, `search_images(query, limit, engine, output_dir, manifest)`, returning `{count, output_dir, manifest_path, skipped, errors}`.
- The `mcp` import is guarded like `duckduckgo.py`'s brotli guard: the module imports fine without it; only `main()`/`_build_server()` raise a helpful error. The core logic lives in `_run_search()`, testable without the optional dep.
- Concurrency follows the documented contract: a module-level lock serializes searches and each call constructs a fresh `Downloader()`.
- Packaging: optional `[mcp]` extra + `bbid-mcp` console script. The base install gains no runtime dependencies; `mcp_server` is deliberately NOT re-exported in `__init__.py`.
- README "MCP server (LLM agents)" section with a Claude Desktop config snippet + CHANGELOG entry.

## Tests

7 new tests in `tests/test_mcp_server.py`: summary-dict shape and kwarg forwarding (mocked `Downloader.search`), manifest=False passthrough, fresh-Downloader-per-call, import-without-mcp simulation, missing-dep error paths, and FastMCP wiring (skipped when `mcp` is absent).

## Verification

- `pytest`: 245 passed, 2 skipped (network)
- `black`, `ruff`, `mypy`: all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCP server for image searching through the new `search_images` tool.
  * Supports configurable queries, result limits, search engines, output directories, and manifests.
  * Returns search totals, output locations, skipped items, and errors.
  * Added stdio startup support through the `bbid-mcp` command.

* **Documentation**
  * Added installation, configuration, and usage instructions for MCP integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->