### PR TITLE
fix(tests): relax version output assertion for cross-platform argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `tests/test_cli.py::test_version_flag_via_argv` failed on Windows
+  (and on any platform when the suite is run via `python -m pytest`)
+  because it asserted `bbid --version`'s output starts with `"bbid "`.
+  Since Python 3.13, argparse derives its default `prog` from
+  `sys.orig_argv` (the real process invocation) whenever it detects a
+  `-m`-style launch, which takes priority over the test's monkeypatched
+  `sys.argv` — so `prog` rendered as `"python.exe -m pytest"` instead.
+  `bbid --version` itself is unaffected; this was a test-strictness
+  bug, not a library bug (issue #68). The test now only asserts what
+  the CLI actually guarantees: exit code 0 and the installed version
+  string (or `"unknown"`) in the output.
+
 ## [3.9.0] - 2026-08-23
 
 ### Added

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,13 +22,24 @@ def _installed_version() -> str | None:
 
 
 def test_version_flag_via_argv(monkeypatch, capsys) -> None:
-    """``bbid --version`` exits 0 and prints the installed version."""
+    """``bbid --version`` exits 0 and prints the installed version.
+
+    Deliberately not asserting the output starts with "bbid ": since
+    Python 3.13, argparse's default ``prog`` is derived from
+    ``sys.orig_argv`` (the real process invocation) whenever it detects
+    the interpreter was started via ``-m``, and that takes priority over
+    a monkeypatched ``sys.argv``. Running this suite via
+    ``python -m pytest`` therefore makes ``prog`` render as
+    ``"python.exe -m pytest"`` regardless of the argv patched above --
+    that's expected argparse behavior, not something this test should
+    fight. ``bbid --version`` run for real (see
+    test_version_flag_via_subprocess below) still prints "bbid ...".
+    """
     monkeypatch.setattr(sys, "argv", ["bbid", "--version"])
     with pytest.raises(SystemExit) as exc_info:
         download.main()
     assert exc_info.value.code == 0
     out = capsys.readouterr().out
-    assert out.startswith("bbid ")
     installed = _installed_version()
     if installed is not None:
         assert installed in out


### PR DESCRIPTION
Fixes #68.

The root cause is slightly more specific than the issue description: since Python 3.13, argparse derives its default `prog` from `sys.orig_argv` (the real process invocation) whenever it detects a `-m`-style launch, and this takes priority over a monkeypatched `sys.argv`. Running the suite via `python -m pytest` therefore renders `prog` as `"python.exe -m pytest"` regardless of what the test patches `sys.argv` to -- confirmed locally on Windows with Python 3.14.

`bbid --version` itself is correct; `test_version_flag_via_subprocess` (which runs the real CLI as a subprocess) already passed throughout. This was purely a test-strictness bug.

**Fix:** drop the `startswith("bbid ")` assertion; assert only what the CLI actually guarantees -- exit code `0` and the installed version string (or `"unknown"`) present in the output.

**Verified:**
- Full suite passes locally: 235 passed, 5 skipped (pre-existing network-test skips)
- `black` / `ruff` clean
- `mypy` has one pre-existing, unrelated error on this file -- confirmed present on `main` too, not introduced here
- `CHANGELOG.md` updated under Unreleased

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of the command-line version display across Windows, Python 3.13, and module-based launches.
  - Version checks now reliably confirm successful execution and display of the installed version.

- **Documentation**
  - Added an unreleased changelog entry describing the command-line version check improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->