### PR TITLE
ci: expand test matrix to Python 3.11 and 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Multimedia :: Graphics",


### PR DESCRIPTION
Hi! Thanks for the great library - the embeddable Downloader API is super clean.

This PR expands CI coverage:
- matrix 3.9,3.10,3.12 -> 3.9,3.10,3.11,3.12,3.13
- project declares requires-python >=3.9 but CI skipped 3.11 (widely deployed) and 3.13 (latest stable)
- no workflow logic change, just two extra matrix entries to catch version-specific regressions early

Verified locally: pytest and ruff still pass. Happy to revert or adjust if you prefer to keep matrix small.

Thanks for maintaining this!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * The project now declares support for Python 3.13.

* **Tests**
  * Automated testing now covers Python versions 3.9 through 3.13, including Python 3.11 and 3.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->